### PR TITLE
Update master

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 1.0.8 Fixed keyboard navigation, 1.0.7 broke tests
 
 1.0.7 Tested support for autocompletes that depend on each other.
-
+ 
 1.0.6 Enhancement: set class 'autocomplete-light-widget' to autocomplete outer
                    containers created by widget.js
 


### PR DESCRIPTION
1.0.8 Fixed keyboard navigation, 1.0.7 broke tests

1.0.7 Tested support for autocompletes that depend on each other.

1.0.6 Enhancement: set class 'autocomplete-light-widget' to autocomplete outer
                   containers created by widget.js

1.0.5 Enhancement: made rest model local object fetcher less harsh when trying
                   to find a local object

1.0.4 Bugfix: registering a generic autocomplete with a custom name did not
              use the custom name

1.0.3 Default search_names to 'name' if the model has a name field

1.0.2 Bugfix & refactor django admin + popup

1.0.1 Slight ergonomy improvement

1.0.0 (Almost) full rewrite

```
- "Channel" is gone in favor of "Autocomplete"
- More unit tests and new selenium tests
- Javascript rewrite, for consistency and documentation
- New view on /autocomplete_light/ allows admins to view the registry
```

0.6 No pity for insane bloat removal

```
Backward compatibility break: {% autocomplete_light_static %} was removed.
Instead, use {% include 'autocomplete_light/static.html' %} as demonstrated
in the "Quick start" documentation.

Note that autocomplete_light/static.html does not include
cities_light/autocomplete.js, so you have to load it yourself now.
```

0.5

```
No backward compatibility break.

- Bugfix in generic channel example: demonstrate how to query_filter on
  multiple queryset types.
- Bugfix in GenericForeignKeyField: allow none value.
- Enhancement: autocomplete_light.contrib.generic_m2m supports generic many
  to many relations.
- Enhancement: allow registration of model with custom channel attributes,
  this allows to register a model with another "search_name" than "name"
  without subclassing.
- Documentation improvements.
```
