### PR TITLE
Remove print statement in widgets.py that causes a mod_wsgi portability violation

### DIFF
--- a/autocomplete_light/widgets.py
+++ b/autocomplete_light/widgets.py
@@ -61,7 +61,6 @@ class WidgetBase(object):
 
         if 'url' not in self.autocomplete_js_attributes.keys():
             url = self.autocomplete().get_absolute_url()
-            print url
             self.autocomplete_js_attributes['url'] = url
 
     def render(self, name, value, attrs=None):


### PR DESCRIPTION
Remove extraneous print statement in widgets.py that causes a mod_wsgi portability violation.

I think this was left in for debugging purposes?  Hopefully it's okay to delete now.

Thanks,
Tyler
