### PR TITLE
Problem with limitation of choices_for_values

### DIFF
--- a/autocomplete_light/autocomplete/choice_list.py
+++ b/autocomplete_light/autocomplete/choice_list.py
@@ -13,7 +13,7 @@ class AutocompleteChoiceList(AutocompleteList):
             if choice[0] in self.values:
                 values_choices.append(choice)
 
-        return self.order_choices(values_choices)[0:self.limit_choices]
+        return self.order_choices(values_choices)
 
     def choices_for_request(self):
         requests_choices = []

--- a/autocomplete_light/autocomplete/list.py
+++ b/autocomplete_light/autocomplete/list.py
@@ -12,7 +12,7 @@ class AutocompleteList(object):
             if choice in self.values:
                 values_choices.append(choice)
 
-        return self.order_choices(values_choices)[0:self.limit_choices]
+        return self.order_choices(values_choices)
 
     def choices_for_request(self):
         assert self.choices, 'autocomplete.choices is not set'

--- a/autocomplete_light/autocomplete/model.py
+++ b/autocomplete_light/autocomplete/model.py
@@ -22,8 +22,8 @@ class AutocompleteModel(object):
 
     def choices_for_values(self):
         assert self.choices is not None, 'choices should be a queryset'
-        return self.order_choices(self.choices.filter(pk__in=self.values or [])
-            )[0:self.limit_choices]
+        return self.order_choices(self.choices.filter(
+            pk__in=self.values or []))
 
     def choices_for_request(self):
         assert self.choices is not None, 'choices should be a queryset'


### PR DESCRIPTION
Enforcing a limitation on the choices available to the already selected values also enforces a limit on the amount of values which can be selected. For example a limit_choices value of 20 would result in an error if more than 20 values were selected using the autocompletion feature. Removing the limit also removes this corner-case problem.
