### PR TITLE
Allow users to submit the form

### DIFF
--- a/autocomplete_light/static/autocomplete_light/autocomplete.js
+++ b/autocomplete_light/static/autocomplete_light/autocomplete.js
@@ -344,6 +344,8 @@ window.yourlabs.Autocomplete = function (input) {
                     this.input.trigger('selectChoice',
                         [choice, this]);
                     this.hide();
+                } else {
+                    $(this.input).parent('form').submit();
                 }
                 break;
             // On KEY_UP, call move()


### PR DESCRIPTION
My goal is for users to submit the form. What I've done on my site is follow the global navigation autocomplete example but my users request the option to submit that form. The code is just a suggestion and if it turns out it's better to do this in site specific javascript I'll gladly rewrite this into a documentation pull request instead.
