### PR TITLE
Use explicit check for None instead of trueness

### DIFF
--- a/autocomplete_light/widgets.py
+++ b/autocomplete_light/widgets.py
@@ -85,7 +85,7 @@ class WidgetBase(object):
         final_attrs = self.build_attrs(attrs)
         self.html_id = final_attrs.pop('id', name)
 
-        if value and not isinstance(value, (list, tuple)):
+        if value is not None and not isinstance(value, (list, tuple)):
             values = [value]
         else:
             values = value


### PR DESCRIPTION
In our legacy database we have a primary key (0) which evaluates False,
but is a legitimate value. That causes the autocompleter to fail with an
exception.
