### PR TITLE
missing namespace and missing test in registry fixed

### DIFF
--- a/autocomplete_light/contrib/hvad.py
+++ b/autocomplete_light/contrib/hvad.py
@@ -16,7 +16,7 @@ def register(*args, **kwargs):
     Decorate the stock register() function, generating an hvad-compatible
     choices queryset.
     """
-    model, autocomplete = AutocompleteRegistry.extract_args(*args)
+    model, autocomplete = autocomplete_light.AutocompleteRegistry.extract_args(*args)
 
     if model is not None and 'choices' not in kwargs and 'lang' in kwargs:
         kwargs['choices'] = model.objects.language(kwargs['lang']).all()

--- a/autocomplete_light/registry.py
+++ b/autocomplete_light/registry.py
@@ -124,7 +124,7 @@ class AutocompleteRegistry(dict):
         else:
             base = autocomplete
 
-        if base.choices is None:
+        if base.choices is None and 'choices' not in kwargs:
             kwargs['choices'] = model.objects.all()
 
         if base.search_fields is None and 'search_fields' not in kwargs:


### PR DESCRIPTION
this works now, but it is not the perfect solution.

a better solution would be if the choices are calculated in the model and filtered with .language(GET['lang']) and GET['q'].

but thanks for the quick fix.

ref #93
