### PR TITLE
jQuery 1.9 support.

### DIFF
--- a/autocomplete_light/static/autocomplete_light/autocomplete.js
+++ b/autocomplete_light/static/autocomplete_light/autocomplete.js
@@ -261,7 +261,7 @@ yourlabs.Autocomplete.prototype.initialize = function() {
     // Set the HTML placeholder attribute on the input.
     this.input.attr('placeholder', this.placeholder);
 
-    this.input.live({
+    this.input.on({
         blur: function() {
             // And hide the autocomplete after a short while.
             window.setTimeout(function() { autocomplete.hide(); },
@@ -279,7 +279,7 @@ yourlabs.Autocomplete.prototype.initialize = function() {
     Bind mouse events to fire signals. Because the same signals will be
     sent if the user uses keyboard to work with the autocomplete.
      */
-    $(this.autocompleteChoiceSelector).live({
+    $(document).on({
         // When the mouse enters a choice ...
         mouseenter: function(e) {
             // ... the first thing we want is to send the dehilight signal
@@ -291,20 +291,24 @@ yourlabs.Autocomplete.prototype.initialize = function() {
             // ... and then sent the hilight signal for the choice.
             autocomplete.input.trigger('hilightChoice',
                 [$(this), autocomplete]);
-        },
+        }},
+        this.autocompleteChoiceSelector);
+    $(document).on({
         mouseleave: function(e) {
             // Send dehilightChoice when the mouse leaves a choice.
             autocomplete.input.trigger('dehilightChoice',
                 [$(this), autocomplete]);
-        },
+        }},
+        this.autocompleteChoiceSelector);
+    $(document).on({
         click: function(e) {
             // Send selectChoice when the user clicks on a choice.
             e.preventDefault();
             e.stopPropagation();
             autocomplete.input.trigger('selectChoice',
                 [$(this), autocomplete]);
-        },
-    });
+        }},
+        this.autocompleteChoiceSelector);
 
     // Bind keyup in the input to call this.refresh()
     this.input.keyup(function(e) { autocomplete.refresh(); });

--- a/autocomplete_light/static/autocomplete_light/remote.js
+++ b/autocomplete_light/static/autocomplete_light/remote.js
@@ -33,7 +33,7 @@ var RemoteAutocompleteWidget = {
 $(document).bind('yourlabsWidgetReady', function() {
     // Instanciate decks with RemoteAutocompleteWidget as override for all widgets with
     // autocomplete 'remote'.
-    $('.autocomplete-light-widget[data-bootstrap=rest_model]').live('initialize', function() {
+    $(document).on('initialize','.autocomplete-light-widget[data-bootstrap=rest_model]', function() {
         $(this).yourlabsWidget(RemoteAutocompleteWidget);
     });
 });

--- a/autocomplete_light/static/autocomplete_light/text_widget.js
+++ b/autocomplete_light/static/autocomplete_light/text_widget.js
@@ -200,7 +200,7 @@ $.fn.yourlabsTextWidget = function(overrides) {
 }
 
 $(document).ready(function() {
-    $('input[data-bootstrap=normal]').live('initialize', function() {
+    $(document).on('initialize','input[data-bootstrap=normal]', function() {
         /*
         Only setup autocompletes on inputs which have data-bootstrap=normal,
         if you want to initialize some autocompletes with custom code, then set
@@ -212,7 +212,7 @@ $(document).ready(function() {
     // Solid initialization, usage::
     //
     //      $(document).bind('yourlabsTextWidgetReady', function() {
-    //          $('.your.autocomplete-light-text-widget').live('initialize', function() {
+    //          $(document).on('initialize','.your.autocomplete-light-text-widget', function() {
     //              $(this).yourlabsTextWidget({
     //                  yourCustomArgs: // ...
     //              })

--- a/autocomplete_light/static/autocomplete_light/widget.js
+++ b/autocomplete_light/static/autocomplete_light/widget.js
@@ -288,7 +288,7 @@ $.fn.yourlabsWidget = function(overrides) {
 }
 
 $(document).ready(function() {
-    $('.autocomplete-light-widget[data-bootstrap=normal]').live('initialize', function() {
+    $(document).on('initialize','.autocomplete-light-widget[data-bootstrap=normal]', function() {
         /*
         Only setup widgets which have data-bootstrap=normal, if you want to
         initialize some Widgets with custom code, then set
@@ -298,7 +298,7 @@ $(document).ready(function() {
     });
 
     // Call Widget.deselectChoice when .remove is clicked
-    $('.autocomplete-light-widget .deck .remove').live('click', function() {
+    $(document).on('click','.autocomplete-light-widget .deck .remove', function() {
         var widget = $(this).parents('.autocomplete-light-widget'
             ).yourlabsWidget();
 
@@ -311,7 +311,7 @@ $(document).ready(function() {
     // Solid initialization, usage:
     //
     //      $(document).bind('yourlabsWidgetReady', function() {
-    //          $('.your.autocomplete-light-widget').live('initialize', function() {
+    //          $(document).on('initialize','.your.autocomplete-light-widget', function() {
     //              $(this).yourlabsWidget({
     //                  yourCustomArgs: // ...
     //              })


### PR DESCRIPTION
On :
http://api.jquery.com/live/
"As of jQuery 1.7, the .live() method is deprecated. Use .on() to attach event handlers."

and on :
http://api.jquery.com/on/
They are some samples used for migration
