### PR TITLE
Forward compatible changes to imports to deal with deprecating elements in Django 1.5

### DIFF
--- a/autocomplete_light/autocomplete/rest_model.py
+++ b/autocomplete_light/autocomplete/rest_model.py
@@ -1,7 +1,12 @@
 import urllib
 
 from django import http
-from django.utils import simplejson
+
+try:
+    from django.utils import simplejson as json
+except ImportError:
+    import json
+
 
 from model import AutocompleteModel
 
@@ -93,7 +98,7 @@ class AutocompleteRestModel(AutocompleteModel):
         except:
             return
         else:
-            for data in simplejson.loads(body):
+            for data in json.loads(body):
                 url = data.pop('url')
 
                 for name in data.keys():
@@ -133,7 +138,7 @@ class AutocompleteRestModel(AutocompleteModel):
         model_class = self.model_for_source_url(url)
 
         fh = urllib.urlopen(url)
-        data = simplejson.loads(fh.read())
+        data = json.loads(fh.read())
         data.pop('url')
         fh.close()
 

--- a/autocomplete_light/urls.py
+++ b/autocomplete_light/urls.py
@@ -5,8 +5,13 @@ autocomplete_light_autocomplete
     Given a 'autocomplete' argument with the name of the autocomplete, this url
     routes to AutocompleteView.
 """
+try:
+    from django.conf.urls.defaults import patterns, url
+except ImportError:
+    from django.conf.urls import patterns, url
 
-from django.conf.urls.defaults import patterns, url
+
+
 from django.views.generic.base import TemplateView
 
 from views import AutocompleteView, RegistryView


### PR DESCRIPTION
Django is dropping its bundled version of simplejson and is recommending Python's standard package. Likewise, Django has changed the location of the import for patterns, url in the URLconf from django.conf.urls.defaults to django.conf.urls.

The changes appear to be forward and backward compatible, but haven't run unit tests against it.
