### PR TITLE
Include widget_template to list of possible templates only when not None

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,6 +6,7 @@ list.
 - Fábio C. Barrionuevo da Luz
 - Marc Hörsken
 - Tyler Kellogg
+- Giorgos Logiotatidis
 - Andreas Madsack
 - Riccardo Magliocchetti
 - Simone Marcarino

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+1.1.26
+- Fixed #114: Use widget_template attr only when set.
+
 1.1.25 Fixed #108: generic inline support.
 
 1.1.24

--- a/autocomplete_light/widgets.py
+++ b/autocomplete_light/widgets.py
@@ -108,14 +108,16 @@ class WidgetBase(object):
             'autocomplete': autocomplete,
         }
         context.update(self.extra_context)
-
-        return safestring.mark_safe(render_to_string([
-            getattr(autocomplete, 'widget_template', ''),
+        templates = [
             'autocomplete_light/%s/widget.html' % autocomplete_name,
             'autocomplete_light/%s/widget.html' % getattr(autocomplete,
                 'widget_template_name', ''),
             'autocomplete_light/widget.html',
-        ], context))
+        ]
+        widget_template = getattr(autocomplete, 'widget_template', None)
+        if widget_template:
+            templates.insert(0, widget_template)
+        return safestring.mark_safe(render_to_string(templates, context))
 
 
 class ChoiceWidget(WidgetBase, forms.Select):


### PR DESCRIPTION
If `widget_template` is not set, then it defaults to `''` and if you have a `templates` directory in the root of your project, then you'll get a 500 error about `.../templates/` being a directory and not a file.

This patch fixes this behavior by adding `widget_template` in the list of possible templates to render, only when the attribute exists.
