### PR TITLE
Make AutocompleteModel break the query into words

### DIFF
--- a/autocomplete_light/autocomplete/model.py
+++ b/autocomplete_light/autocomplete/model.py
@@ -41,10 +41,11 @@ class AutocompleteModel(object):
                 return "%s__icontains" % field_name
 
         conditions = Q()
-        if q:
+        for word in q.strip().split():
+            word_conditions = Q()
             for search_field in self.search_fields:
-                conditions |= Q(**{construct_search(search_field): q})
-
+                word_conditions |= Q(**{construct_search(search_field): word})
+            conditions &= word_conditions
         return self.order_choices(self.choices.filter(
             conditions).exclude(pk__in=exclude))[0:self.limit_choices]
 


### PR DESCRIPTION
Hey, remember #78? Well, upon further review, I found that what eventually got committed did not break the query string down into words in the same way the Django admin search does. This pull fixes that.

Now it could be, you left that out on purpose, because it does change the search behavior somewhat. Personally, I have a database with about 120k people in it, and use this package to do autocompletions on their names, and it looks like this:

``` python
class PersonAutocomplete(autocomplete_light.AutocompleteModelBase):

    choices = Person.objects.all().order_by("surname", "given_name")

    search_fields = (
        '^given_name',
        '^nickname',
        '^surname'
    )
```

In a nutshell, this patch allows multiple words in the search, and all the words must appear in each result, i.e. each word must match at least one of the search_fields. Multiple words can dramatically reduce the size of the result set in this case, by allowing partial multi-word matches to work.

This passes the test suite, but it does change the search behavior a bit, so as I suggested in #78, maybe it would be a good idea to have a split_words attribute (default False) on AutocompleteModel so that the default behavior doesn't change. If you want it, I'll update the pull request.
