### PR TITLE
Update autocomplete.js

### DIFF
--- a/autocomplete_light/static/autocomplete_light/autocomplete.js
+++ b/autocomplete_light/static/autocomplete_light/autocomplete.js
@@ -206,6 +206,11 @@ yourlabs.Autocomplete.prototype.initialize = function() {
         .on('mouseenter', this.choiceSelector, $.proxy(this.boxMouseenter, this))
         .on('mouseleave', this.choiceSelector, $.proxy(this.boxMouseleave, this))
         .on('click', this.choiceSelector, $.proxy(this.boxClick, this))
+    
+    /*
+    Initially - empty data queried
+    */
+    this.data[this.queryVariable] = '';
 }
 
 // Unbind callbacks on input.


### PR DESCRIPTION
fix for problem, when setting 'minimum_characters': 0 doesn't work as it should (However, you may want the autocomplete to behave like a select. If you want that a simple click shows the autocomplete, set this to 0.)

initial query data should be empty, cuz there are nothing to compare in hasChanged
