### PR TITLE
Works with a Django-Suit admin.

### DIFF
--- a/autocomplete_light/templates/admin/base_site.html
+++ b/autocomplete_light/templates/admin/base_site.html
@@ -2,6 +2,11 @@
 {% load admin_static %}
 
 {% block extrahead %}
-{{block.super}}
+<script 
+  type='text/javascript' 
+  src='//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js'>
+</script>
+
 {% include 'autocomplete_light/static.html' %}
+{{block.super}}
 {% endblock %}


### PR DESCRIPTION
Adding the base_site.html template makes autocomplete-light work with a Django-Suit enabled admin. I wonder if this breaks other django app combinations?

Make sure the INSTALLED_APPS are in the correct order, the following works:

```
INSTALLED_APPS = (
    'autocomplete_light',
    'suit',            
    'cms',
    'you-custom-app',
    'django.contrib.admin',
)
```

Cheers,

Ivan
