### PR TITLE
Change unicode to str in CreateView for Python 3

### DIFF
--- a/autocomplete_light/views.py
+++ b/autocomplete_light/views.py
@@ -78,7 +78,7 @@ class CreateView(generic.CreateView):
         html = []
         html.append(u'<script type="text/javascript">')
         html.append(u'opener.dismissAddAnotherPopup( window, "%s", "%s" );' % (
-            unicode(obj.pk), unicode(obj).replace('"', '\\"')))
+            str(obj.pk), str(obj).replace('"', '\\"')))
         html.append(u'</script>')
 
         html = u''.join(html)


### PR DESCRIPTION
Hello. This fixes a NameError for me.

```
global name 'unicode' is not defined

/home/***/.virtualenvs/memoria/lib/python3.3/site-packages/autocomplete_light/views.py in respond_script
            unicode(obj.pk), unicode(obj).replace('"', '\\"'))) ...
```

I don't know if this is the best way, I think it only works for Python 3.
