### PR TITLE
Fix tests: allow to confige DB user and "set -e"

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -11,21 +11,22 @@ DJANGO_TAGGIT="${DJANGO_TAGGIT:-1}"
 DJANGO_GENERIC_M2M="${DJANGO_GENERIC_M2M:-1}"
 PYTHON_VERSION="${PYTHON_VERSION:-3.3}"
 DJANGO_VERSION="${DJANGO_VERSION:-1.5}"
+POSTGRES_USER="${POSTGRES_USER:-postgres}"
 # for debug, it could be -e /dev/stdout
 XVFB_FLAGS="${XVFB_FLAGS:-}"
 export DATABASE_NAME="autocomplete_light_test_${BUILD_ID}${PYTHON_VERSION}${DJANGO_VERSION}${DJANGO_TAGGIT}${DJANGO_GENERIC_M2M}"
 export DATABASE_NAME="${DATABASE_NAME//[._-]}"
 
 function clean {
-    psql -c "drop database if exists $DATABASE_NAME;" -U postgres
+    psql -c "drop database if exists $DATABASE_NAME;" -U $POSTGRES_USER
 }
 trap 'clean; exit' SIGINT SIGQUIT
 
 # Make a unique env path for this configuration
 ENV_PATH="$WORKSPACE/test_env"
 
-psql -c "drop database if exists $DATABASE_NAME;" -U postgres
-psql -c "create database $DATABASE_NAME;" -U postgres
+psql -c "drop database if exists $DATABASE_NAME;" -U $POSTGRES_USER
+psql -c "create database $DATABASE_NAME;" -U $POSTGRES_USER
 
 # Get real django version
 [ "$DJANGO_VERSION" = "1.4" ] && DJANGO_VERSION="1.4.10"

--- a/test_project/test_project/settings_postgres.py
+++ b/test_project/test_project/settings_postgres.py
@@ -6,8 +6,8 @@ from .settings import *
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2', # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': os.environ.get('DATABASE_NAME', 'autocomplete_light_test'),                      # Or path to database file if using sqlite3.
-        'USER': 'postgres',                      # Not used with sqlite3.
+        'NAME': os.environ.get('DATABASE_NAME', 'autocomplete_light_test'), # Or path to database file if using sqlite3.
+        'USER': os.environ.get('POSTGRES_USER', 'postgres'), # Not used with sqlite3.
         'PASSWORD': '',                  # Not used with sqlite3.
         'HOST': '',                      # Set to empty string for localhost. Not used with sqlite3.
         'PORT': '',                      # Set to empty string for default. Not used with sqlite3.


### PR DESCRIPTION
I consider "set -e" to be quite important here, otherwise you might install your current environment (e.g. if python-3.3 is not available etc).

I am new to PostgreSQL, and it might be specific to Debian/Ubuntu, but I have seen that there is a pg_virtualenv command, which takes care of setting up a cluster for tests: http://manpages.ubuntu.com/cgi-bin/search.py?q=pg_virtualenv
