### PR TITLE
IE11 compability check

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,3 +31,4 @@ list.
 - Brant Young
 - Fidel Ramos
 - Nick Catalano (@nickcatal)
+- Jonathan Wiklund (@MaZZly)

--- a/autocomplete_light/static/autocomplete_light/text_widget.js
+++ b/autocomplete_light/static/autocomplete_light/text_widget.js
@@ -27,14 +27,14 @@ jQuery.fn.getSelectionStart = function(){
     var pos = input.value.length;
  
     if (input.createTextRange) {
-	if (window.getSelection) {
+        if (window.getSelection) {
             var r = window.getSelection(); //IE11
         } else {
             var r = document.selection.createRange().duplicate();
             r.moveEnd('character', input.value.length);
         }
         if (r.text == '')
-        pos = input.value.length;
+            pos = input.value.length;
         pos = input.value.lastIndexOf(r.text);
     } else if(typeof(input.selectionStart)!="undefined")
     pos = input.selectionStart;


### PR DESCRIPTION
IE11 autocomplete on textfields doesn't work due to:
http://msdn.microsoft.com/en-us/library/ie/ms535869(v=vs.85).aspx

This fixes that =)
