### PR TITLE
Django 1.7 SimpleAdminConfig use import error fix

### DIFF
--- a/autocomplete_light/registry.py
+++ b/autocomplete_light/registry.py
@@ -231,7 +231,7 @@ def _autodiscover(registry):
     for app in settings.INSTALLED_APPS:
         try:
             mod = import_module(app)
-        except ImportError, e:
+        except ImportError:
             #not all entries in INSTALLED_APPS are have to be modules
             continue
         # Attempt to import the app's admin module.


### PR DESCRIPTION
From Django 1.7 release notes: django.contrib.admin will now automatically perform autodiscovery of admin modules in installed applications. To prevent it, change your INSTALLED_APPS to contain 'django.contrib.admin.apps.SimpleAdminConfig' instead of 'django.contrib.admin'.

So using default admin app causes `autocomplete_light.exceptions.AutocompleteNotRegistered (registry is empty)` error.
Temporary workaround is to use SimpleAdminConfig, but it seems like current behaviour must be changed from one described in docs: http://django-autocomplete-light.readthedocs.org/en/latest/install.html#call-autocomplete-light-autodiscover-before-admin-autodiscover
