### PR TITLE
Should only compile gettext messages when building sdist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,25 +35,10 @@ class RunTests(Command):
         os.chdir(this_dir)
 
 if 'sdist' in sys.argv:
-    # clear compiled mo files before building the distribution
-    walk = os.walk(os.path.join(os.getcwd(), 'autocomplete_light/locale'))
-    for dirpath, dirnames, filenames in walk:
-        if not filenames:
-            continue
-
-        if 'django.mo' in filenames:
-            os.unlink(os.path.join(dirpath, 'django.mo'))
-else:
-    # if django is there, compile the po files to mo
-    try:
-        import django
-    except ImportError:
-        pass
-    else:
-        dir = os.getcwd()
-        os.chdir(os.path.join(dir, 'autocomplete_light'))
-        os.system('django-admin.py compilemessages')
-        os.chdir(dir)
+    dir = os.getcwd()
+    os.chdir(os.path.join(dir, 'autocomplete_light'))
+    os.system('django-admin.py compilemessages')
+    os.chdir(dir)
 
 setup(
     name='django-autocomplete-light',


### PR DESCRIPTION
```
Running setup.py install for django-autocomplete-light
    sh: 1: django-admin.py: not found
```

You cannot have django-autocomplete-light with `pip install -r requirements.txt` when django itself is part of that file -- in that case `django-admin.py` won't be in the executable path.
