### PR TITLE
js: wrap CSRF javascript in jQuery(function(){})

### DIFF
--- a/autocomplete_light/templates/autocomplete_light/_ajax_csrf.html
+++ b/autocomplete_light/templates/autocomplete_light/_ajax_csrf.html
@@ -1,6 +1,5 @@
 <script type="text/javascript">
-
-// using jQuery
+jQuery(function($) {
 function getCookie(name) {
     var cookieValue = null;
     if (document.cookie && document.cookie != '') {
@@ -16,7 +15,6 @@ function getCookie(name) {
     }
     return cookieValue;
 }
-var csrftoken = getCookie('csrftoken');
 function csrfSafeMethod(method) {
     // these HTTP methods do not require CSRF protection
     return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
@@ -40,10 +38,9 @@ $.ajaxSetup({
             // Send the token to same-origin, relative URLs only.
             // Send the token only if the method warrants CSRF protection
             // Using the CSRFToken value acquired earlier
-            xhr.setRequestHeader("X-CSRFToken", csrftoken);
+            xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
         }
     }
 });
-
-
+});
 </script>


### PR DESCRIPTION
Also remove the unnecessary `csrftoken` variable and use the `getCookie`
function directly.
