### PR TITLE
Fix handling of invalid choices in `choices_for_values`

### DIFF
--- a/autocomplete_light/autocomplete/model.py
+++ b/autocomplete_light/autocomplete/model.py
@@ -79,7 +79,7 @@ class AutocompleteModel(object):
         """
         assert self.choices is not None, 'choices should be a queryset'
         return self.order_choices(self.choices.filter(
-            pk__in=self.values or []))
+            pk__in=[x for x in self.values if x]))
 
     def choices_for_request(self):
         """


### PR DESCRIPTION
Would benefit from some test for this. I think it's much easier for you to add one, otherwise let me know.

The `or []` might not be void.

Fixes https://github.com/yourlabs/django-autocomplete-light/issues/62
