### PR TITLE
tox.ini: do not install `django` twice

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,4 +8,5 @@ install_command = pip install -U --allow-external --allow-insecure progressbar {
 deps =
     -rtest_project/test_requirements.txt
 setenv =
+    DJANGO_SETTINGS_MODULE=test_project.settings
     PIP_ALLOW_EXTERNAL=true


### PR DESCRIPTION
Fixes:

> Double requirement given: django (from -r test_project/requirements.txt (line 3)) (already in django, name='django')"
