### PR TITLE
test_requirements: do not pin selenium to 2.37.2

### DIFF
--- a/test_project/test_requirements.txt
+++ b/test_project/test_requirements.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 mock
 psycopg2
-selenium==2.37.2
+selenium
 lxml
 cssselect


### PR DESCRIPTION
I was seeing the following error with selenium tests, which is fixed in
a later version:

> WebDriverException: Message: "Can't load the profile. Profile Dir: …"
