### PR TITLE
Use stopImmediatePropagation to stop nested autocomplete clicks from cascading

### DIFF
--- a/autocomplete_light/static/autocomplete_light/autocomplete.js
+++ b/autocomplete_light/static/autocomplete_light/autocomplete.js
@@ -312,6 +312,7 @@ yourlabs.Autocomplete.prototype.boxMouseleave = function(e) {
 
 // When mouse clicks in the box:
 yourlabs.Autocomplete.prototype.boxClick = function(e) {
+    e.stopImmediatePropagation(); // avoid issues with nested autocompletes
     var current = this.box.find('.' + this.hilightClass);
     
     this.input.trigger('selectChoice', [current, this]);


### PR DESCRIPTION
I have a situation in which the "not found" formatted HTML contains an "add" form, which includes autocompletes itself, and the boxClick in the inner one would trigger events in the outer one without this.
