### PR TITLE
Django 1.8 deprecation messages fix

### DIFF
--- a/autocomplete_light/forms.py
+++ b/autocomplete_light/forms.py
@@ -425,6 +425,8 @@ def modelform_factory(model, autocomplete_fields=None,
 
     attrs = {'model': model}
 
+    attrs['exclude'] = ('', )
+
     if autocomplete_fields is not None:
         attrs['autocomplete_fields'] = autocomplete_fields
     if autocomplete_exclude is not None:


### PR DESCRIPTION
Fix of deprecation messages that may appear when you start application server due to django 1.8 deprecations: 

lib/python2.7/site-packages/autocomplete_light/forms.py:449: RemovedInDjango18Warning: Calling modelform_factory without defining 'fields' or 'exclude' explicitly is deprecated
  return django_modelform_factory(model, **kwargs)
