### PR TITLE
Little changes to avoid bad style to underlying html elements

### DIFF
--- a/autocomplete_light/static/autocomplete_light/autocomplete.js
+++ b/autocomplete_light/static/autocomplete_light/autocomplete.js
@@ -506,7 +506,7 @@ yourlabs.Autocomplete.prototype.fixPosition = function() {
 
     this.input.parents().filter(function() {
         return $(this).css('overflow') === 'hidden';
-    }).first().css('overflow', 'visible');
+    }).first().css('overflow', 'visible').addClass('autocomplete-light-clearfix');
 	
     this.box.insertAfter(this.input).css(
             {top: pos.top + pos.height, left: pos.left});

--- a/autocomplete_light/static/autocomplete_light/style.css
+++ b/autocomplete_light/static/autocomplete_light/style.css
@@ -153,6 +153,19 @@ input.autocomplete.xhr-pending {
     display: none;
 }
 
+/* These lines are important to avoid style change to the underlying divs */
+.autocomplete-light-clearfix:before,
+.autocomplete-light-clearfix:after {
+    content: " "; 
+    display: table; 
+}
+.autocomplete-light-clearfix:after {
+    clear: both;
+}
+.autocomplete-light-clearfix {
+    *zoom: 1;
+}
+
 /* grappelli specific */
 fieldset.grp-module .grp-row {
     overflow: visible !important;


### PR DESCRIPTION
Little modifications to remove strange effect to underlying html elements in django admin

You can see what happens before 
![schermata 2014-11-14 alle 12 53 38](https://cloud.githubusercontent.com/assets/2088831/5052204/9e4c322a-6c3e-11e4-8554-e1d23c253258.png)

and after my modifications
![schermata 2014-11-14 alle 12 54 10](https://cloud.githubusercontent.com/assets/2088831/5052207/aa485496-6c3e-11e4-91e0-0d642e270371.png)
