### PR TITLE
[v1] Fix for positioning of MultipleChoiceWidget drop-down

### DIFF
--- a/autocomplete_light/static/autocomplete_light/autocomplete.js
+++ b/autocomplete_light/static/autocomplete_light/autocomplete.js
@@ -509,7 +509,7 @@ yourlabs.Autocomplete.prototype.fixPosition = function() {
     }).first().css('overflow', 'visible').addClass('autocomplete-light-clearfix');
 	
     this.box.insertAfter(this.input).css(
-            {top: pos.top + pos.height, left: pos.left});
+            {top: pos.height, left: pos.left});
 }
 
 // Proxy fetch(), with some sanity checks.


### PR DESCRIPTION
This fixes an issue I had with the 1.4 branch where each subsequent drop down appears lower down the screen than it should, resulting in it being unusable after a few items have been entered. Not tested with 2.x