### PR TITLE
register: default to admin `search_fields`, fallback to 'name'/'title'

### DIFF
--- a/autocomplete_light/autocomplete/model.py
+++ b/autocomplete_light/autocomplete/model.py
@@ -4,8 +4,6 @@ import six
 from django.utils.encoding import force_text
 from django.db.models import Q
 
-from ..settings import DEFAULT_SEARCH_FIELDS
-
 __all__ = ('AutocompleteModel', )
 
 
@@ -44,7 +42,7 @@ class AutocompleteModel(object):
     """
     limit_choices = 20
     choices = None
-    search_fields = DEFAULT_SEARCH_FIELDS
+    search_fields = None
     split_words = False
     order_by = None
 

--- a/autocomplete_light/exceptions.py
+++ b/autocomplete_light/exceptions.py
@@ -25,6 +25,15 @@ class AutocompleteArgNotUnderstood(AutocompleteLightException):
         super(AutocompleteArgNotUnderstood, self).__init__(msg)
 
 
+class UnconfiguredSearchFieldsException(Exception):
+    """
+    Raised by :func:`AutocompleteRegistry._register_model_autocomplete` when no
+    :attr:`search_fields` were provided and could not be determined
+    automatically.
+    """
+    pass
+
+
 class NoGenericAutocompleteRegistered(AutocompleteLightException):
     """
     Raised by AutocompleteRegistry.autocomplete_for_generic when no generic

--- a/autocomplete_light/registry.py
+++ b/autocomplete_light/registry.py
@@ -29,6 +29,7 @@ from .exceptions import (AutocompleteArgNotUnderstood,
                          AutocompleteNotRegistered,
                          NoGenericAutocompleteRegistered,
                          UnconfiguredSearchFieldsException)
+from .settings import DEFAULT_SEARCH_FIELDS
 
 try:
     from django.utils.module_loading import autodiscover_modules
@@ -182,7 +183,7 @@ class AutocompleteRegistry(dict):
                 # Use 'name' and/or 'title' fields.
                 model_fields = model._meta.get_all_field_names()
                 search_fields = tuple(
-                    f for f in model_fields if f in ('name', 'title')
+                    f for f in model_fields if f in (DEFAULT_SEARCH_FIELDS)
                 )
             if not search_fields:
                 raise UnconfiguredSearchFieldsException(

--- a/autocomplete_light/registry.py
+++ b/autocomplete_light/registry.py
@@ -177,7 +177,7 @@ class AutocompleteRegistry(dict):
         if base.search_fields is None and 'search_fields' not in kwargs:
             try:
                 search_fields = admin.site._registry[model].search_fields
-            except KeyError:
+            except (KeyError, AttributeError):
                 search_fields = ()
             if not search_fields:
                 # Use 'name' and/or 'title' fields.


### PR DESCRIPTION
Followup of https://github.com/yourlabs/django-autocomplete-light/pull/301 against master.

Fixes https://github.com/yourlabs/django-autocomplete-light/issues/239.
