### PR TITLE
Replacing clear-fix with newer version, as the older version breaks the ...

### DIFF
--- a/autocomplete_light/static/autocomplete_light/style.css
+++ b/autocomplete_light/static/autocomplete_light/style.css
@@ -154,16 +154,10 @@ input.autocomplete.xhr-pending {
 }
 
 /* These lines are important to avoid style change to the underlying divs */
-.autocomplete-light-clearfix:before,
 .autocomplete-light-clearfix:after {
-    content: " "; 
+    content: "";
     display: table; 
-}
-.autocomplete-light-clearfix:after {
     clear: both;
-}
-.autocomplete-light-clearfix {
-    *zoom: 1;
 }
 
 /* grappelli specific */


### PR DESCRIPTION
...display of inline forms in Django 1.7.
See discussion: https://github.com/yourlabs/django-autocomplete-light/pull/334#issuecomment-75745309