### PR TITLE
Be friendly with special html chars in values

### DIFF
--- a/autocomplete_light/static/autocomplete_light/text_widget.js
+++ b/autocomplete_light/static/autocomplete_light/text_widget.js
@@ -142,7 +142,7 @@ yourlabs.TextWidget.prototype.selectChoice = function(choice) {
 
 // Return the value of an HTML choice, used to fill the input.
 yourlabs.TextWidget.prototype.getValue = function(choice) {
-    return $.trim(choice.html().replace(/(<([^>]+)>)/ig,""));
+    return $.trim(choice.text());
 }
 
 // Initialize the widget.


### PR DESCRIPTION
Hey guys, I’ve stumbled over the case where I wanted to select a value containing an ampersand (“&”) from the autocomplete box, and the escaped value (“&amp;”) was inserted into the text input.

This PR fixes the issue.

I would appreciate if you could push a release to pip soon. Thanks!