### PR TITLE
Fix super().__self_class__ AttributeError crash on PyPy

### DIFF
--- a/autocomplete_light/fields.py
+++ b/autocomplete_light/fields.py
@@ -30,6 +30,8 @@ class FieldBase(object):
                     autocomplete_js_attributes, extra_context)
         kwargs['widget'] = widget
 
+        # Does the subclass have ModelChoiceField or ModelMultipleChoiceField
+        # as a direct base class?
         parents = super(FieldBase, self).__self_class__.__bases__
         if ((forms.ModelChoiceField in parents or
                 forms.ModelMultipleChoiceField in parents) and

--- a/autocomplete_light/fields.py
+++ b/autocomplete_light/fields.py
@@ -32,7 +32,7 @@ class FieldBase(object):
 
         # Does the subclass have ModelChoiceField or ModelMultipleChoiceField
         # as a direct base class?
-        parents = super(FieldBase, self).__self_class__.__bases__
+        parents = type(self).__bases__
         if ((forms.ModelChoiceField in parents or
                 forms.ModelMultipleChoiceField in parents) and
                 isinstance(self.autocomplete.choices, QuerySet)):


### PR DESCRIPTION
On PyPy, `FieldBase` crashes with the following error:

```
Traceback (most recent call last):
  ...
  File ".../autocomplete_light/fields.py", line 33, in __init__
    parents = super(FieldBase, self).__self_class__.__bases__
AttributeError: 'super' object has no attribute '__self_class__'
```

I am not sure why the code tries to access `__self_class__` like this instead of using `type(self)`: they should be equivalent in this case. The code was added in 5732ffd792a47a0c1258fd6ea47489dccb023b14, but that does not enlighten me.

Replacing the attribute access with `type(self)` lets the test suite pass successfully on PyPy 2.3.1 here.

Regarding the same line of code, I am also not sure why only `__bases__` is being inspected, instead of using a simple `instanceof` check. Is there a special reason? I want to update this PR to either document it, or to replace it with `instanceof`.

Also, after fixing this, could PyPy be added to the Travis test configuration?