### PR TITLE
[FIX] "open parentheses" cannot be typed on Chrome/Mac

### DIFF
--- a/autocomplete_light/static/autocomplete_light/autocomplete.js
+++ b/autocomplete_light/static/autocomplete_light/autocomplete.js
@@ -451,7 +451,7 @@ yourlabs.Autocomplete.prototype.move = function(e) {
 
     // If not KEY_UP or KEY_DOWN, then return.
     if (e.keyCode == 38 && !e.shiftKey) var way = 'up';
-    else if (e.keyCode == 40) var way = 'down';
+    else if (e.keyCode == 40 && !e.shiftKey) var way = 'down';
     else return;
 
     // The first and last choices. If the user presses down on the last


### PR DESCRIPTION
The (shift+9) *open parentheses* `(` cannot be typed on autocomplete field. Fixed hinted by 51e20fa.