### PR TITLE
Fix RemovedInDjango19Warning

### DIFF
--- a/autocomplete_light/widgets.py
+++ b/autocomplete_light/widgets.py
@@ -16,7 +16,7 @@ template.
 """
 
 from django import forms
-from django.forms.util import flatatt
+from django.forms.utils import flatatt
 from django.utils import safestring
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _


### PR DESCRIPTION
 RemovedInDjango19Warning: The django.forms.util module has been renamed. Use django.forms.utils instead.
  from django.forms.util import flatatt