### PR TITLE
Fix RemovedInDjango19Warning on GenericForeignKey

### DIFF
--- a/autocomplete_light/fields.py
+++ b/autocomplete_light/fields.py
@@ -5,7 +5,10 @@ from django import forms
 from django.db import models
 from django.db.models.query import QuerySet
 from django import forms
-from django.contrib.contenttypes.generic import GenericForeignKey
+try:
+    from django.contrib.contenttypes.fields import GenericForeignKey
+except ImportError:
+    from django.contrib.contenttypes.generic import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 
 from .registry import registry as default_registry


### PR DESCRIPTION
RemovedInDjango19Warning: django.contrib.contenttypes.generic is deprecated and will be removed in Django 1.9. Its contents have been moved to the fields, forms, and admin sub
modules of django.contrib.contenttypes.
  from django.contrib.contenttypes.generic import GenericForeignKey