### PR TITLE
AutocompleteModel.choices_for_values() retains ordering of values

### DIFF
--- a/autocomplete_light/autocomplete/model.py
+++ b/autocomplete_light/autocomplete/model.py
@@ -39,8 +39,8 @@ class AutocompleteModel(object):
 
     .. py:attribute:: order_by
 
-        If set, it will be used to order choices. It can be a single field name
-        or an iterable (ie. list, tuple).
+        If set, it will be used to order choices in the deck. It can be a single
+        field name or an iterable (ie. list, tuple).
     """
     limit_choices = 20
     choices = None

--- a/autocomplete_light/tests/autocomplete/test_model.py
+++ b/autocomplete_light/tests/autocomplete/test_model.py
@@ -40,6 +40,13 @@ class AutocompleteModelTestCase(AutocompleteTestCase):
                     self.john,
                 ]
             },
+            {
+                'fixture': [4, 1],
+                'expected': [
+                    self.john,
+                    self.abe,
+                ]
+            },
         )
 
     def get_choices_for_request_tests(self):


### PR DESCRIPTION
To start with, added a failing test which asserts the AutocompleteModel.choices_for_values() does not modify the ordering of the values.

Otherwise, no implementation yet; this PR is not complete.