### PR TITLE
Prefer mousedown and specify input

### DIFF
--- a/autocomplete_light/static/autocomplete_light/autocomplete.js
+++ b/autocomplete_light/static/autocomplete_light/autocomplete.js
@@ -262,7 +262,7 @@ yourlabs.Autocomplete.prototype.initialize = function() {
     this.box
         .on('mouseenter', this.choiceSelector, $.proxy(this.boxMouseenter, this))
         .on('mouseleave', this.choiceSelector, $.proxy(this.boxMouseleave, this))
-        .on('click', this.choiceSelector, $.proxy(this.boxClick, this));
+        .on('mousedown', this.choiceSelector, $.proxy(this.boxClick, this));
 
     /*
     Initially - empty data queried

--- a/autocomplete_light/static/autocomplete_light/widget.js
+++ b/autocomplete_light/static/autocomplete_light/widget.js
@@ -50,7 +50,7 @@ Instanciate a Widget.
 yourlabs.Widget = function(widget) {
     // These attributes where described above.
     this.widget = widget;
-    this.input = this.widget.find('input');
+    this.input = this.widget.find('input[data-autocomplete-url]');
     this.select = this.widget.find('select');
     this.deck = this.widget.find('.deck');
     this.choiceTemplate = this.widget.find('.choice-template .choice');


### PR DESCRIPTION
Hello,
Thanks to your amazing package I've been able to fulfill my most advanced UX desires, you made some nice work here :)

Although I've found two small things that bothered me:

1. Prefering mousedown instead of click event allows to work on data already processed by autocomplete
2. I've used readonly inputs in my choice template, but they get picked up at initialisation, so I needed to specify the original input