### PR TITLE
Get the primary key name from choices so does not have to be id

### DIFF
--- a/autocomplete_light/autocomplete/model.py
+++ b/autocomplete_light/autocomplete/model.py
@@ -75,8 +75,8 @@ class AutocompleteModel(object):
                 pass
 
             # Order in the user selection order when self.values is set.
-            clauses = ' '.join(['WHEN %s="%s" THEN %s' % (pk_name, pk, i) for i, pk in
-                    enumerate(self.values)])
+            clauses = ' '.join(['WHEN %s="%s" THEN %s' % (pk_name, pk, i)
+                for i, pk in enumerate(self.values)])
             ordering = 'CASE %s END' % clauses
             return choices.extra(
                 select={'ordering': ordering}, order_by=('ordering',))

--- a/autocomplete_light/autocomplete/model.py
+++ b/autocomplete_light/autocomplete/model.py
@@ -67,8 +67,9 @@ class AutocompleteModel(object):
         Order choices using :py:attr:`order_by` option if it is set.
         """
         if self.values:
+            pk_name = choices[0]._meta.pk.name
             # Order in the user selection order when self.values is set.
-            clauses = ' '.join(['WHEN id=%s THEN %s' % (pk, i) for i, pk in
+            clauses = ' '.join(['WHEN %s="%s" THEN %s' % (pk_name, pk, i) for i, pk in
                     enumerate(self.values)])
             ordering = 'CASE %s END' % clauses
             return choices.extra(

--- a/autocomplete_light/autocomplete/model.py
+++ b/autocomplete_light/autocomplete/model.py
@@ -67,7 +67,13 @@ class AutocompleteModel(object):
         Order choices using :py:attr:`order_by` option if it is set.
         """
         if self.values:
-            pk_name = choices[0]._meta.pk.name
+            pk_name = "id"
+            try:
+                if len(choices) > 0:
+                    pk_name = choices[0]._meta.pk.name
+            except:
+                pass
+
             # Order in the user selection order when self.values is set.
             clauses = ' '.join(['WHEN %s="%s" THEN %s' % (pk_name, pk, i) for i, pk in
                     enumerate(self.values)])


### PR DESCRIPTION
Right now if you attempt to use autocomplete-light on a table where the primary key is not id, you get a id field error.