### PR TITLE
Fix #408: Support Django 1.8 change-link.

### DIFF
--- a/autocomplete_light/static/autocomplete_light/widget.js
+++ b/autocomplete_light/static/autocomplete_light/widget.js
@@ -79,6 +79,8 @@ yourlabs.Widget.prototype.initializeAutocomplete = function() {
 
 // Bind Autocomplete.selectChoice signal to Widget.selectChoice()
 yourlabs.Widget.prototype.bindSelectChoice = function() {
+    var widget = this;
+
     this.input.bind('selectChoice', function(e, choice) {
         if (!choice.length)
             return // placeholder: create choice here
@@ -87,6 +89,8 @@ yourlabs.Widget.prototype.bindSelectChoice = function() {
             ).yourlabsWidget();
 
         widget.selectChoice(choice);
+
+        widget.widget.trigger('widgetSelectChoice', [choice, widget]);
     });
 };
 
@@ -230,6 +234,8 @@ yourlabs.Widget.prototype.deselectChoice = function(choice) {
 
     this.updateAutocompleteExclude();
     this.resetDisplay();
+
+    this.widget.trigger('widgetDeselectChoice', [choice, this]);
 };
 
 yourlabs.Widget.prototype.updateAutocompleteExclude = function() {
@@ -363,6 +369,34 @@ $(document).ready(function() {
 
     $('.autocomplete-light-widget:not([id*="__prefix__"])').each(function() {
         $(this).trigger('initialize');
+    });
+
+    $(document).bind('widgetDeselectChoice', function(e, choice, widget) {
+        /*
+        Unset the .change-related link when an item is selected.
+
+        For django 1.8 admin support.
+        */
+        var next = widget.widget.next();
+        var template = next.attr('data-href-template');
+
+        if (template && next.is('.change-related') && next.attr('href')) {
+            next.removeAttr('href');
+        }
+    });
+
+    $(document).bind('widgetSelectChoice', function(e, choice, widget) {
+        /*
+        Set the .change-related link when an item is selected.
+
+        For django 1.8 admin support.
+        */
+        var next = widget.widget.next();
+        var template = next.attr('data-href-template');
+
+        if (template && next.is('.change-related')) {
+            next.attr('href', template.replace('__fk__', widget.getValue(choice)));
+        }
     });
 
     $(document).bind('DOMNodeInserted', function(e) {

--- a/autocomplete_light/tests/test_widget.py
+++ b/autocomplete_light/tests/test_widget.py
@@ -328,7 +328,7 @@ class RemoveChoiceInEditFormTestCase(WidgetTestCase):
         self.set_implicit_wait()
 
     def test_admin_change_link_has_no_href(self):
-        change_link = self.selenium.find_element_by_id('change_id_relation')
+        change_link = self.selenium.find_element_by_id('change_id_%s' % self.autocomplete_name)
         href = change_link.get_attribute('href')
         assert href is None
 

--- a/autocomplete_light/tests/test_widget.py
+++ b/autocomplete_light/tests/test_widget.py
@@ -272,6 +272,11 @@ class SelectChoiceInEmptyFormTestCase(WidgetTestCase):
     def test_hidden_select_value(self):
         self.assertEqual(self.select_values(), ['4'])
 
+    def test_admin_change_link_update(self):
+        change_link = self.selenium.find_element_by_id('change_id_%s' % self.autocomplete_name)
+        href = change_link.get_attribute('href')
+        assert href.endswith('/admin/basic/fkmodel/4/?_to_field=id&_popup=1')
+
 
 @unittest.skipIf(Tag is None, 'django-taggit not installed')
 class TextWidgetWithTaggitForm(WidgetTestCase):
@@ -321,6 +326,11 @@ class RemoveChoiceInEditFormTestCase(WidgetTestCase):
         self.unset_implicit_wait()
         self.assertEqual(0, len(self.deck_choices()))
         self.set_implicit_wait()
+
+    def test_admin_change_link_has_no_href(self):
+        change_link = self.selenium.find_element_by_id('change_id_relation')
+        href = change_link.get_attribute('href')
+        assert href is None
 
 
 class KeyboardTestCase(WidgetTestCase):


### PR DESCRIPTION
This is not my favorite fix, ideally we'd have seen this coming by
building against the master branch and were able to participate to the
elaboration of this admin widget.

So, the widget now has 2 new events it triggers:

- widgetSelectChoice,
- widgetDeselectChoice.

Also, a couple of callbacks were bound to those to support Django 1.8
change-link href management.