### PR TITLE
Fix #410: Removed double validation

### DIFF
--- a/autocomplete_light/fields.py
+++ b/autocomplete_light/fields.py
@@ -49,8 +49,6 @@ class FieldBase(object):
         """
         Wrap around Autocomplete.validate_values().
         """
-        super(FieldBase, self).validate(value)
-
         # FIXME: we might actually want to change the Autocomplete API to
         # support python values instead of raw values, that would probably be
         # more performant.


### PR DESCRIPTION
Since validation is taken care of in the Autocomplete, there is no need to call it twice.