### PR TITLE
Fix #412: Support models with a pk different than "id" and non-numeric.

### DIFF
--- a/autocomplete_light/autocomplete/model.py
+++ b/autocomplete_light/autocomplete/model.py
@@ -75,8 +75,8 @@ class AutocompleteModel(object):
                 pass
 
             # Order in the user selection order when self.values is set.
-            clauses = ' '.join(['WHEN %s="%s" THEN %s' % (pk_name, pk, i) for i, pk in
-                    enumerate(self.values)])
+            clauses = ' '.join(['WHEN %s="%s" THEN %s' % (pk_name, pk, i)
+                for i, pk in enumerate(self.values)])
             ordering = 'CASE %s END' % clauses
             return choices.extra(
                 select={'ordering': ordering}, order_by=('ordering',))

--- a/autocomplete_light/autocomplete/model.py
+++ b/autocomplete_light/autocomplete/model.py
@@ -66,6 +66,9 @@ class AutocompleteModel(object):
         """
         Order choices using :py:attr:`order_by` option if it is set.
         """
+        if isinstance(self.order_by, six.string_types):
+            self.order_by = (self.order_by,)
+
         if self.values:
             pk_name = "id"
             try:
@@ -78,15 +81,17 @@ class AutocompleteModel(object):
             clauses = ' '.join(['WHEN %s="%s" THEN %s' % (pk_name, pk, i)
                 for i, pk in enumerate(self.values)])
             ordering = 'CASE %s END' % clauses
+
+            _order_by = ('ordering',)
+            if self.order_by:
+                _order_by += self.order_by
+
             return choices.extra(
                 select={'ordering': ordering},
-                order_by=('ordering',)+tuple(self.order_by))
+                order_by=_order_by)
 
         if self.order_by is None:
             return choices
-
-        if isinstance(self.order_by, six.string_types):
-            return choices.order_by(self.order_by)
 
         return choices.order_by(*self.order_by)
 

--- a/autocomplete_light/autocomplete/model.py
+++ b/autocomplete_light/autocomplete/model.py
@@ -79,7 +79,8 @@ class AutocompleteModel(object):
                 for i, pk in enumerate(self.values)])
             ordering = 'CASE %s END' % clauses
             return choices.extra(
-                select={'ordering': ordering}, order_by=('ordering',))
+                select={'ordering': ordering},
+                order_by=('ordering',)+tuple(self.order_by))
 
         if self.order_by is None:
             return choices

--- a/autocomplete_light/autocomplete/model.py
+++ b/autocomplete_light/autocomplete/model.py
@@ -67,8 +67,9 @@ class AutocompleteModel(object):
         Order choices using :py:attr:`order_by` option if it is set.
         """
         if self.values:
+            pk_name = choices[0]._meta.pk.name
             # Order in the user selection order when self.values is set.
-            clauses = ' '.join(['WHEN id=%s THEN %s' % (pk, i) for i, pk in
+            clauses = ' '.join(['WHEN %s="%s" THEN %s' % (pk_name, pk, i) for i, pk in
                     enumerate(self.values)])
             ordering = 'CASE %s END' % clauses
             return choices.extra(

--- a/autocomplete_light/autocomplete/model.py
+++ b/autocomplete_light/autocomplete/model.py
@@ -67,7 +67,13 @@ class AutocompleteModel(object):
         Order choices using :py:attr:`order_by` option if it is set.
         """
         if self.values:
-            pk_name = choices[0]._meta.pk.name
+            pk_name = "id"
+            try:
+                if len(choices) > 0:
+                    pk_name = choices[0]._meta.pk.name
+            except:
+                pass
+
             # Order in the user selection order when self.values is set.
             clauses = ' '.join(['WHEN %s="%s" THEN %s' % (pk_name, pk, i) for i, pk in
                     enumerate(self.values)])

--- a/autocomplete_light/example_apps/autocomplete_test_case_app/autocomplete_light_registry.py
+++ b/autocomplete_light/example_apps/autocomplete_test_case_app/autocomplete_light_registry.py
@@ -1,0 +1,6 @@
+from autocomplete_light import shortcuts
+
+from .models import NonIntegerPk
+
+
+shortcuts.register(NonIntegerPk)

--- a/autocomplete_light/example_apps/autocomplete_test_case_app/forms.py
+++ b/autocomplete_light/example_apps/autocomplete_test_case_app/forms.py
@@ -1,0 +1,9 @@
+from autocomplete_light import shortcuts
+
+from .models import NonIntegerPk
+
+
+class NonIntegerPkForm(shortcuts.ModelForm):
+    class Meta:
+        model = NonIntegerPk
+        exclude = []

--- a/autocomplete_light/example_apps/autocomplete_test_case_app/models.py
+++ b/autocomplete_light/example_apps/autocomplete_test_case_app/models.py
@@ -9,3 +9,12 @@ class User(models.Model):
 
 class Group(models.Model):
     name = models.CharField(max_length=100)
+
+
+class NonIntegerPk(models.Model):
+    name = models.CharField(primary_key=True, max_length=10)
+    relation = models.ForeignKey('self', null=True, blank=True)
+    noise = models.ForeignKey('basic.FkModel', null=True, blank=True)
+
+    for_inline = models.ForeignKey('self', null=True, blank=True,
+                                   related_name='inline')

--- a/autocomplete_light/tests/test_forms.py
+++ b/autocomplete_light/tests/test_forms.py
@@ -13,6 +13,8 @@ from ..example_apps.basic.forms import (DjangoCompatMeta, FkModelForm,
                                         GfkModelForm, MtmModelForm,
                                         OtoModelForm)
 from ..example_apps.basic.models import FkModel, GfkModel, MtmModel, OtoModel
+from ..example_apps.autocomplete_test_case_app.models import NonIntegerPk
+from ..example_apps.autocomplete_test_case_app.forms import NonIntegerPkForm
 
 try:
     from unittest import mock
@@ -561,3 +563,10 @@ class GmtmModelFormTestCase(MultipleRelationMixin,
 
     def field_value(self, model):
         return getattr(model, 'relation').all().generic_objects()[0]
+
+
+class NonIntegerPkTestCase(ModelFormBaseMixin, TestCase):
+    model_class = NonIntegerPk
+    model_form_class = NonIntegerPkForm
+    field_class = autocomplete_light.ModelChoiceField
+    autocomplete_name = 'NonIntegerPkAutocomplete'


### PR DESCRIPTION
This is #412 with tests.