### PR TITLE
ANSI SQL does not allow double quotes for enclosing string literals.

### DIFF
--- a/autocomplete_light/autocomplete/model.py
+++ b/autocomplete_light/autocomplete/model.py
@@ -78,7 +78,7 @@ class AutocompleteModel(object):
                 pass
 
             # Order in the user selection order when self.values is set.
-            clauses = ' '.join(['WHEN %s="%s" THEN %s' % (pk_name, pk, i)
+            clauses = ' '.join(['WHEN %s=\'%s\' THEN %s' % (pk_name, pk, i)
                 for i, pk in enumerate(self.values)])
             ordering = 'CASE %s END' % clauses
 


### PR DESCRIPTION
PostgreSQL will interpret double quoted strings as column names, so we must use single quotes instead.