### PR TITLE
Fix #429: call Field.validate() to handle required.

### DIFF
--- a/autocomplete_light/fields.py
+++ b/autocomplete_light/fields.py
@@ -47,8 +47,12 @@ class FieldBase(object):
 
     def validate(self, value):
         """
-        Wrap around Autocomplete.validate_values().
+        Wrap around forms.Field and Autocomplete.validate_values().
+
+        Field.validate_values() handles the required option.
         """
+        forms.Field.validate(self, value)
+
         # FIXME: we might actually want to change the Autocomplete API to
         # support python values instead of raw values, that would probably be
         # more performant.

--- a/autocomplete_light/tests/test_fields.py
+++ b/autocomplete_light/tests/test_fields.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+import pytest
+
 import autocomplete_light.shortcuts as autocomplete_light
 from django import forms
 from django.contrib.contenttypes.models import ContentType
@@ -13,6 +15,7 @@ class BaseMixin(object):
     GOOD_VALUE = 'b'
     CLEANED_VALUE = 'b'
     BAD_VALUE = 'xx'
+    EMPTY_VALUE = None
 
     class TestAutocomplete(autocomplete_light.AutocompleteListBase):
         choices = ['a', 'b', 'c']
@@ -27,6 +30,12 @@ class BaseMixin(object):
 
         with self.assertRaises(forms.ValidationError):
             test.validate(self.BAD_VALUE)
+
+    def test_validate_required(self):
+        test = self.field_class(self.TestAutocomplete, required=True)
+
+        with pytest.raises(forms.ValidationError):
+            test.validate(self.EMPTY_VALUE)
 
     def test_select_choice(self):
         class TestForm(forms.Form):


### PR DESCRIPTION
Fix for issue #429.

Like `django/forms/models.py`'s own `validate()`.