### PR TITLE
Dynamic evaluation of the autocomp box container.

### DIFF
--- a/autocomplete_light/static/autocomplete_light/autocomplete.js
+++ b/autocomplete_light/static/autocomplete_light/autocomplete.js
@@ -288,8 +288,14 @@ yourlabs.Autocomplete = function (input) {
     /*
     We'll append the box to the container and calculate an absolute position
     every time the autocomplete is shown in the fixPosition method.
+
+    By default, this traverses this.input's parents to find the nearest parent
+    with an 'absolute' or 'fixed' position. This prevents scrolling / resizing
+    issues that we'd have by boldly using <body>.
     */
-    this.container = $('body');
+    this.container = this.input.parents().filter(function() {
+        return ['absolute', 'fixed'].indexOf($(this).css('position')) > -1;
+    }).first();
 };
 
 /*


### PR DESCRIPTION
In 2.2.0 series, we want most complete support of Django admin - which means
all edge cases - and it's oldschool overflow: hidden way of clearing floats.

On the other hand, we also want top-notch support for modern CSS patterns such
as the .clearfix which is the most-standard way of clearing floats IMHO and is
of course the way all modern CSS frameworks clear their floats.

By default, this traverses this.input's parents to find the nearest parent
with an 'absolute' or 'fixed' position. This prevents scrolling issues that
we'd have by boldly using <body>.