### PR TITLE
Fix #447: Wrong pk_name on subclasses.

### DIFF
--- a/autocomplete_light/autocomplete/model.py
+++ b/autocomplete_light/autocomplete/model.py
@@ -71,7 +71,7 @@ class AutocompleteModel(object):
 
         if self.values:
             pk_name = ('id' if not getattr(choices.model._meta, 'pk', None)
-                    else choices.model._meta.pk.attname)
+                    else choices.model._meta.pk.column)
             pk_name = '%s.%s' % (choices.model._meta.db_table, pk_name)
 
             # Order in the user selection order when self.values is set.

--- a/autocomplete_light/autocomplete/model.py
+++ b/autocomplete_light/autocomplete/model.py
@@ -71,7 +71,7 @@ class AutocompleteModel(object):
 
         if self.values:
             pk_name = ('id' if not getattr(choices.model._meta, 'pk', None)
-                    else choices.model._meta.pk.name)
+                    else choices.model._meta.pk.attname)
             pk_name = '%s.%s' % (choices.model._meta.db_table, pk_name)
 
             # Order in the user selection order when self.values is set.

--- a/autocomplete_light/example_apps/autocomplete_test_case_app/models.py
+++ b/autocomplete_light/example_apps/autocomplete_test_case_app/models.py
@@ -18,3 +18,7 @@ class NonIntegerPk(models.Model):
 
     for_inline = models.ForeignKey('self', null=True, blank=True,
                                    related_name='inline')
+
+
+class SubGroup(Group):
+    pass

--- a/autocomplete_light/example_apps/autocomplete_test_case_app/models.py
+++ b/autocomplete_light/example_apps/autocomplete_test_case_app/models.py
@@ -22,3 +22,10 @@ class NonIntegerPk(models.Model):
 
 class SubGroup(Group):
     pass
+
+
+class CustomSchema(models.Model):
+    name = models.CharField(primary_key=True, max_length=10, db_column='bar')
+
+    class Meta:
+        db_table = 'foobar'

--- a/autocomplete_light/tests/autocomplete/test_model.py
+++ b/autocomplete_light/tests/autocomplete/test_model.py
@@ -6,7 +6,7 @@ import pytest
 from django import VERSION
 from django.utils.encoding import force_text
 
-from autocomplete_light.example_apps.autocomplete_test_case_app.models import NonIntegerPk
+from autocomplete_light.example_apps.autocomplete_test_case_app.models import NonIntegerPk, SubGroup
 from .case import *
 
 
@@ -188,3 +188,12 @@ class AutocompleteModelTestCase(AutocompleteTestCase):
         fixture = Test(values=[NonIntegerPk.objects.create(name='bal').pk])
         # Call len to force evaluate queryset
         len(fixture.choices_for_values())
+
+    def test_inherited_model_ambiguous_column_name(self):
+        subgroup = SubGroup.objects.create(name='test')
+
+        class Test(autocomplete_light.AutocompleteModelBase):
+            choices = SubGroup.objects.all()
+
+        fixture = Test(values=[subgroup.pk])
+        assert fixture.choices_for_values()[0] == subgroup

--- a/autocomplete_light/tests/autocomplete/test_model.py
+++ b/autocomplete_light/tests/autocomplete/test_model.py
@@ -6,7 +6,8 @@ import pytest
 from django import VERSION
 from django.utils.encoding import force_text
 
-from autocomplete_light.example_apps.autocomplete_test_case_app.models import NonIntegerPk, SubGroup
+from autocomplete_light.example_apps.autocomplete_test_case_app.models import (
+        NonIntegerPk, SubGroup, CustomSchema)
 from .case import *
 
 
@@ -197,3 +198,12 @@ class AutocompleteModelTestCase(AutocompleteTestCase):
 
         fixture = Test(values=[subgroup.pk])
         assert fixture.choices_for_values()[0] == subgroup
+
+    def test_custom_table_and_name(self):
+        obj = CustomSchema.objects.create(name='test')
+
+        class Test(autocomplete_light.AutocompleteModelBase):
+            choices = CustomSchema.objects.all()
+
+        fixture = Test(values=[obj.pk])
+        assert fixture.choices_for_values()[0] == obj


### PR DESCRIPTION
The test should fail as such without the patched autocomplete/model.py::
```
========================================================= FAILURES ==========================================================
___________________________ AutocompleteModelTestCase.test_inherited_model_ambiguous_column_name ____________________________

self = <autocomplete_light.tests.autocomplete.test_model.AutocompleteModelTestCase testMethod=test_inherited_model_ambiguous_column_name>

    def test_inherited_model_ambiguous_column_name(self):
        class Test(autocomplete_light.AutocompleteModelBase):
            choices = SubGroup.objects.all()

        fixture = Test(values=[SubGroup.objects.create(name='test')])
        # Call len to force evaluate queryset
>       len(fixture.choices_for_values())

autocomplete_light/tests/autocomplete/test_model.py:198:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
.tox/py34-django18/lib/python3.4/site-packages/django/db/models/query.py:144: in __len__
    self._fetch_all()
.tox/py34-django18/lib/python3.4/site-packages/django/db/models/query.py:965: in _fetch_all
    self._result_cache = list(self.iterator())
.tox/py34-django18/lib/python3.4/site-packages/django/db/models/query.py:238: in iterator
    results = compiler.execute_sql()
.tox/py34-django18/lib/python3.4/site-packages/django/db/models/sql/compiler.py:840: in execute_sql
    cursor.execute(sql, params)
.tox/py34-django18/lib/python3.4/site-packages/django/db/backends/utils.py:64: in execute
    return self.cursor.execute(sql, params)
.tox/py34-django18/lib/python3.4/site-packages/django/db/utils.py:97: in __exit__
    six.reraise(dj_exc_type, dj_exc_value, traceback)
.tox/py34-django18/lib/python3.4/site-packages/django/utils/six.py:658: in reraise
    raise value.with_traceback(tb)
.tox/py34-django18/lib/python3.4/site-packages/django/db/backends/utils.py:64: in execute
    return self.cursor.execute(sql, params)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <django.db.backends.sqlite3.base.SQLiteCursorWrapper object at 0x7fa93d27ec18>
query = 'SELECT (CASE WHEN autocomplete_test_case_app_subgroup.group_ptr=\'SubGroup object\' THEN 0 END) AS "ordering", "autoc..._test_case_app_group"."id" ) WHERE "autocomplete_test_case_app_su
bgroup"."group_ptr_id" IN (?) ORDER BY "ordering" ASC'
params = (11,)

    def execute(self, query, params=None):
        if params is None:
            return Database.Cursor.execute(self, query)
        query = self.convert_query(query)
>       return Database.Cursor.execute(self, query, params)
E       django.db.utils.OperationalError: no such column: autocomplete_test_case_app_subgroup.group_ptr
```