### PR TITLE
Foreign key with 0 as PK is valid.

### DIFF
--- a/autocomplete_light/autocomplete/model.py
+++ b/autocomplete_light/autocomplete/model.py
@@ -99,7 +99,7 @@ class AutocompleteModel(object):
         """
         assert self.choices is not None, 'choices should be a queryset'
         return self.order_choices(self.choices.filter(
-            pk__in=[x for x in self.values if x]))
+            pk__in=[x for x in self.values if x != '']))
 
     def choices_for_request(self):
         """

--- a/autocomplete_light/example_apps/autocomplete_test_case_app/models.py
+++ b/autocomplete_light/example_apps/autocomplete_test_case_app/models.py
@@ -20,6 +20,10 @@ class NonIntegerPk(models.Model):
                                    related_name='inline')
 
 
+class CustomIntegerPk(models.Model):
+    id = models.IntegerField(primary_key=True)
+
+
 class SubGroup(Group):
     pass
 

--- a/autocomplete_light/tests/autocomplete/test_model.py
+++ b/autocomplete_light/tests/autocomplete/test_model.py
@@ -7,7 +7,7 @@ from django import VERSION
 from django.utils.encoding import force_text
 
 from autocomplete_light.example_apps.autocomplete_test_case_app.models import (
-        NonIntegerPk, SubGroup, CustomSchema)
+        NonIntegerPk, SubGroup, CustomSchema, CustomIntegerPk)
 from .case import *
 
 
@@ -207,3 +207,12 @@ class AutocompleteModelTestCase(AutocompleteTestCase):
 
         fixture = Test(values=[obj.pk])
         assert fixture.choices_for_values()[0] == obj
+
+    def test_primary_key_zero(self):
+        obj = CustomIntegerPk.objects.create(id=0)
+
+        class Test(autocomplete_light.AutocompleteModelBase):
+            choices = CustomIntegerPk.objects.all()
+
+        fixture = Test(values=[obj.pk])
+        self.assertEqual(list(fixture.choices_for_values()), [obj])


### PR DESCRIPTION
If you added an FK with 0 as primary key, autocomplete would complain
that it was invalid because it filtered out everything Python considered
falsy after a fix to #62 was provided in #298.

After this, autocomplete validation will check directly for the empty
string '' instead of falsy values.