### PR TITLE
Crash fix for AutocompleteModel.order_by

### DIFF
--- a/autocomplete_light/autocomplete/model.py
+++ b/autocomplete_light/autocomplete/model.py
@@ -81,7 +81,9 @@ class AutocompleteModel(object):
 
             _order_by = ('ordering',)
             if self.order_by:
-                _order_by += self.order_by
+                # safe concatenation of list/tuple
+                # thanks lvh from #python@freenode
+                _order_by = set(_order_by) | set(self.order_by)
 
             return choices.extra(
                 select={'ordering': ordering},


### PR DESCRIPTION
When one defines AutocompleteModel.order_by as a list, which the [documentation](http://django-autocomplete-light.readthedocs.org/en/stable-2.x.x/api.html#autocomplete_light.autocomplete.model.AutocompleteModel.order_by) specifically says is supported, one gets a crash stating "can only concatenate tuple (not "list") to tuple". This is because the code was doing:

    _order_by = ('ordering',)
    if self.order_by
        _order_by += self.order_by

My patch replaces that with a bit of code from `autocomplete_light/forms.py`, which does a safe concatenation between any two iterables.

This fix could also be implemented by creating `_order_by` as a list and using `_order_by.extend(self.order_by)`, since `extend()` accepts any iterable.