### PR TITLE
tox.ini: add DISPLAY to passenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ setenv =
     PYTHONPATH=test_project
     postgresql: DJANGO_SETTINGS_MODULE=test_project.settings_postgres
     mysql: DJANGO_SETTINGS_MODULE=test_project.settings_mysql
-passenv = TESTS_SKIP_LIVESERVER TESTS_WEBDRIVER
+passenv = TESTS_SKIP_LIVESERVER TESTS_WEBDRIVER DISPLAY
 
 [testenv:checkqa]
 basepython = python3.4


### PR DESCRIPTION
This is required to fix the following error with `tox -e py34-django18`
(using Firefox):

> selenium.common.exceptions.WebDriverException: Message: The browser appears to have exited before we could connect.

@jpic 
Did this work for you locally?
Are you using another webdriver?