### PR TITLE
[fix] Docs : missing {{ block.super }} can create confusing bugs

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -123,6 +123,7 @@ For admin support, `override
     {% extends "admin/base.html" %}
 
     {% block extrahead %}
+        {{ block.super }}
         <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.js" type="text/javascript"></script>
         {% include 'autocomplete_light/static.html' %}
     {% endblock %}


### PR DESCRIPTION
I think it would be better to include `{{ block.super }}` in this step of the installation process. 
I spent a bit of time on the following bug : 
I'm using django-suit and followed the installation process of django-autocomplete-light almost by the letter, except for this particular step where I copied the `{% block extrahead %} ... {% endblock %}` without `{{ block.super }}` in a file extending `admin/change_form.html` instead of `admin/base.html`.

This particular manipulation caused django-suit to never display the button "Add another Inline" when editing/adding a new object.

Adding `{{ block.super }}` fixed it and autocomplete now works flawlessly for me. Unexperienced users might have a hard time finding the source of this bug.