### PR TITLE
Widget's render should use attrs even when created wthing __init__

### DIFF
--- a/autocomplete_light/example_apps/basic/autocomplete_light_registry.py
+++ b/autocomplete_light/example_apps/basic/autocomplete_light_registry.py
@@ -16,11 +16,21 @@ for model in models:
 
 
 class A(autocomplete_light.AutocompleteGenericBase):
-    choices=[m.objects.all() for m in models]
-    search_fields=[['name']] * len(models)
+    choices = [m.objects.all() for m in models]
+    search_fields = [['name']] * len(models)
 
+class A2(autocomplete_light.AutocompleteGenericBase):
+    choices = [m.objects.all() for m in models]
+    search_fields = [['name']] * len(models)
+    values = ['1','2', '3' ]
+    attrs = {'data-class-defined': 1}
+
+    def __init__(self, *args, **kw):
+        self.attrs = self.attrs.copy()
+        self.attrs.update({'data-init-defined': 2})
 
 autocomplete_light.register(A)
+autocomplete_light.register(A2)
 
 
 # The autocomplete for class B is used to set up the test case for
@@ -28,11 +38,21 @@ autocomplete_light.register(A)
 # This bug is triggered only when the autocomplete is registered with a
 # widget_attrs dictionary.
 class B(autocomplete_light.AutocompleteGenericBase):
-    choices=[m.objects.all() for m in models]
-    search_fields=[['name']] * len(models)
+    choices = [m.objects.all() for m in models]
+    search_fields = [['name']] * len(models)
+
+class B2(autocomplete_light.AutocompleteGenericBase):
+    choices = [m.objects.all() for m in models]
+    search_fields = [['name']] * len(models)
+    attrs = {'data-class-defined': 1}
+
+    def __init__(self, *args, **kw):
+        self.attrs = self.attrs.copy()
+        self.attrs.update({'data-init-defined': 2})
 
 
 autocomplete_light.register(B, widget_attrs={'data-widget-maximum-values': 4})
+autocomplete_light.register(B2, )
 
 
 try:

--- a/autocomplete_light/tests/test_widgets.py
+++ b/autocomplete_light/tests/test_widgets.py
@@ -161,9 +161,21 @@ class WidgetBaseMixin(object):
         self.assertEqual(len(choices), 1)
         self.assertEqual(int(choices[0].attrib['data-value']), 1)
 
-
 class ChoiceWidgetTestCase(WidgetBaseMixin, TestCase):
     widget_class = autocomplete_light.ChoiceWidget
+
+    def test_attrs_copy_class(self):
+        widget = self.widget_class('A2')
+        html = widget.render('taggit', value='oky')
+        et = etree.XML(html)
+        self.assertTrue(et.find('input').get('data-class-defined'), '1')
+
+    def test_attrs_copy_init(self):
+        widget = self.widget_class('A2')
+        html = widget.render('taggit', value='oky')
+        et = etree.XML(html)
+
+        self.assertTrue(et.find('input').get('data-init-defined'), '2')
 
 
 class MultipleChoiceWidgetTestCase(WidgetBaseMixin, TestCase):
@@ -204,3 +216,15 @@ class TextWidgetTestCase(WidgetBaseMixin, TestCase):
         html = widget.render('taggit', None)
         et = etree.XML(html)
         self.assertFalse('value' in et.attrib)
+
+    def test_attrs_copy_class(self):
+        widget = self.widget_class('B2')
+        html = widget.render('taggit', value='oky')
+        et = etree.XML(html)
+        self.assertTrue('data-class-defined' in et.attrib)
+
+    def test_attrs_copy_init(self):
+        widget = self.widget_class('B2')
+        html = widget.render('taggit', value='oky')
+        et = etree.XML(html)
+        self.assertTrue('data-init-defined' in et.attrib)

--- a/autocomplete_light/widgets.py
+++ b/autocomplete_light/widgets.py
@@ -157,10 +157,13 @@ class WidgetBase(object):
 
     def render(self, name, value, attrs=None):
         widget_attrs = self.build_widget_attrs(name)
-        attrs = self.build_attrs(attrs)
-        self.html_id = attrs.pop('id', name)
 
         autocomplete = self.autocomplete(values=value)
+
+        attrs = self.build_attrs(attrs, autocomplete=autocomplete)
+
+        self.html_id = attrs.pop('id', name)
+
         choices = autocomplete.choices_for_values()
         values = [autocomplete.choice_value(c) for c in choices]
 
@@ -179,8 +182,8 @@ class WidgetBase(object):
                 self.widget_template)
         return safestring.mark_safe(render_to_string(template, context))
 
-    def build_attrs(self, extra_attrs=None, **kwargs):
-        self.attrs.update(getattr(self.autocomplete, 'attrs', {}))
+    def build_attrs(self, extra_attrs=None, autocomplete=None, **kwargs):
+        self.attrs.update(getattr(autocomplete, 'attrs', {}))
         attrs = super(WidgetBase, self).build_attrs(extra_attrs, **kwargs)
 
         if 'class' not in attrs.keys():
@@ -297,12 +300,17 @@ class TextWidget(WidgetBase, forms.TextInput):
 
     def render(self, name, value, attrs=None):
         """ Proxy Django's TextInput.render() """
+
+        autocomplete = self.autocomplete(values=value)
+        attrs = self.build_attrs(attrs, autocomplete=autocomplete)
+
         return forms.TextInput.render(self, name, value, attrs)
 
-    def build_attrs(self, extra_attrs=None, **kwargs):
+    def build_attrs(self, extra_attrs=None, autocomplete=None, **kwargs):
         attrs = super(TextWidget, self).build_widget_attrs()
         attrs.update(super(TextWidget, self).build_attrs(
             extra_attrs, **kwargs))
+        attrs.update(getattr(autocomplete, 'attrs', {}))
 
         def update_attrs(source, prefix=''):
             for key, value in source.items():


### PR DESCRIPTION
While working with autocomplete I realized that any attribute added from within __init__ will not be used by the render function. I thing this is not optimal as it is counterintuitive and results in code that is not DRY.

TIA
sandro
*:-)