### PR TITLE
ModelChoiceFields: Watch changes to 'queryset'

### DIFF
--- a/autocomplete_light/fields.py
+++ b/autocomplete_light/fields.py
@@ -86,16 +86,30 @@ class MultipleChoiceField(ChoiceField, forms.MultipleChoiceField):
     widget = MultipleChoiceWidget
 
 
-class ModelChoiceField(FieldBase, forms.ModelChoiceField):
+class ModelChoiceFieldBase(FieldBase):
+    def _get_queryset(self):
+        return self._queryset
+
+    def _set_queryset(self, queryset):
+        self._queryset = queryset
+        self.widget.choices = self.choices
+
+        # Also update autocomplete choices
+        self.autocomplete.choices = queryset
+
+    queryset = property(_get_queryset, _set_queryset)
+
+
+class ModelChoiceField(ModelChoiceFieldBase, forms.ModelChoiceField):
     widget = ChoiceWidget
 
 
-class ModelMultipleChoiceField(FieldBase,
+class ModelMultipleChoiceField(ModelChoiceFieldBase,
         forms.ModelMultipleChoiceField):
     widget = MultipleChoiceWidget
 
 
-class GenericModelChoiceField(FieldBase, forms.Field):
+class GenericModelChoiceField(ModelChoiceFieldBase, forms.Field):
     """
     Simple form field that converts strings to models.
     """

--- a/autocomplete_light/tests/test_forms.py
+++ b/autocomplete_light/tests/test_forms.py
@@ -172,8 +172,10 @@ class ModelFormBaseMixin(BaseModelFormMixin):
         class ModelForm(autocomplete_light.ModelForm):
             class Meta(DjangoCompatMeta):
                 model = self.model_class
-                widgets = {'relation': self.widget_class(widget_attrs={
-                    'class': 'test-class', 'data-foo': 'bar'})}
+                widgets = {'relation': self.widget_class(
+                    autocomplete=self.autocomplete_name,
+                    widget_attrs={'class': 'test-class', 'data-foo': 'bar'}
+                )}
 
         self.form = ModelForm()
 


### PR DESCRIPTION
A ModelChoiceField's 'queryset' attribute may be overwritten after the field has been created, for example in order to limit the choices that are offered. We should also reflect these changes in the autocompletion.

A common idiom is to override ``queryset`` in a view or form, like in this example: https://docs.djangoproject.com/en/dev/ref/forms/fields/#fields-which-handle-relationships. Currently, these overrides are not reflected in the autocomplete. Hence it is possible to select related objects in the autocomplete that aren't part of ``queryset`` anymore, resulting in a validation error.

This patch fixes this by always reflecting changes to ``queryset`` in the autocomplete's choices.