### PR TITLE
support to register model by 'app_name.ModelName' or

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@ __pycache__
 test_env/
 .coverage
 .tox
+
+.cache/
+
+# Pycharm
+.idea/

--- a/AUTHORS
+++ b/AUTHORS
@@ -23,7 +23,7 @@ documentation to the project.
 - Derek Stegelman
 - Dmitri Bogomolov
 - Ewoud Kohl van Wijngaarden
-- Fábio C. Barrioneuvo da Luz
+- Fábio C. Barrionuevo da Luz
 - Fidel Ramos
 - Florentin Hennecker
 - Gabriel Rodríguez Alberich

--- a/autocomplete_light/compat.py
+++ b/autocomplete_light/compat.py
@@ -9,7 +9,51 @@ else:
     patterns = None
 
 
+try:
+    # Django 1.7 or over use the new application loading system
+    from django.apps import apps
+    get_model = apps.get_model
+except ImportError:
+    from django.db.models.loading import get_model
+
+try:
+    from django.utils.module_loading import import_string
+except ImportError:
+    from importlib import import_module
+    from django.utils import six
+    import sys
+
+    def import_string(dotted_path):
+        """
+        Import a dotted module path and return the attribute/class designated
+        by the last name in the path. Raise ImportError if the import failed.
+        Backported from Django 1.8
+        """
+        try:
+            module_path, class_name = dotted_path.rsplit('.', 1)
+        except ValueError:
+            msg = "%s doesn't look like a module path" % dotted_path
+            six.reraise(ImportError, ImportError(msg), sys.exc_info()[2])
+
+        module = import_module(module_path)
+
+        try:
+            return getattr(module, class_name)
+        except AttributeError:
+            msg = 'Module "%s" does not define a "%s" attribute/class' % (
+                module_path, class_name)
+            six.reraise(ImportError, ImportError(msg), sys.exc_info()[2])
+
+
 def urls(urls):
     if patterns:
         return patterns('', *urls)
     return urls
+
+__all__ = (
+    'get_model',
+    'import_string',
+    'urls',
+    'url',
+    'patterns'
+)

--- a/autocomplete_light/exceptions.py
+++ b/autocomplete_light/exceptions.py
@@ -45,3 +45,7 @@ class AutocompleteChoicesMustBeQuerySet(AutocompleteLightException):
         msg = ('%s.choices must be a QuerySet to support ModelChoiceField' %
             autocomplete)
         super(AutocompleteChoicesMustBeQuerySet, self).__init__(msg)
+
+
+class NonDjangoModelSubclassException(AutocompleteLightException):
+    pass

--- a/autocomplete_light/shortcuts.py
+++ b/autocomplete_light/shortcuts.py
@@ -3,7 +3,7 @@ from .contrib.taggit_field import TaggitField, TaggitWidget
 from .exceptions import (AutocompleteArgNotUnderstood,
                          AutocompleteChoicesMustBeQuerySet,
                          AutocompleteLightException, AutocompleteNotRegistered,
-                         NoGenericAutocompleteRegistered)
+                         NoGenericAutocompleteRegistered, NonDjangoModelSubclassException)
 from .fields import *
 from .forms import *
 from .registry import AutocompleteRegistry, autodiscover, register, registry

--- a/autocomplete_light/tests/test_registry.py
+++ b/autocomplete_light/tests/test_registry.py
@@ -126,6 +126,45 @@ class RegistryTestCase(TestCase):
         self.assertTrue(issubclass(
             self.registry.autocomplete_for_generic(), FirstAutocomplete))
 
+    def test_register_model_as_string_app_name_dot_model_name(self):
+        self.registry.register('auth.User')
+        self.assertIn('UserAutocomplete', self.registry.keys())
+
+    def test_register_model_as_string_invalid_app_name_dot_model_name(self):
+        try:
+            self.registry.register('invalid_appname.User')
+            self.fail('Should raise an exception because "LookupError: No installed app with label invalid_appname"')
+        except LookupError:
+            pass
+
+    def test_register_model_as_string_app_name_dot_invalid_model_name(self):
+        try:
+            self.registry.register('django.contrib.auth.models.UserWrong')
+            self.fail(
+                'Should raise an exception because "ImportError: Module '
+                '"django.contrib.auth.models" does not define a \"UserWrong\" attribute/class"')
+        except ImportError:
+            pass
+
+    def test_register_model_as_string_full_dot_path_to_model(self):
+        self.registry.register('django.contrib.auth.models.User')
+        self.assertIn('UserAutocomplete', self.registry.keys())
+
+    def test_register_model_as_string_full_dot_path_to_non_model(self):
+        try:
+            self.registry.register('django.contrib.auth.forms.UserCreationForm')
+            self.fail('Should raise an exception NonDjangoModelSubclassException because '
+                      'UserCreationForm not is subclass of django Model')
+        except autocomplete_light.NonDjangoModelSubclassException:
+            pass
+
+    def test_register_model_as_string_invalid_full_dot_path_to_non_model(self):
+        try:
+            self.registry.register('django.invalid_path.UserCreationForm')
+            self.fail('Should raise an exception because is invalid dot path to Model')
+        except ImportError:
+            pass
+
 
 class RegistryGetAutocompleteFromArgTestCase(TestCase):
     def setUp(self):


### PR DESCRIPTION
 'full.path.to.Model'

My use case:

```python
import autocomplete_light
from django.conf import settings

USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')


class UserAutocomplete(autocomplete_light.AutocompleteModelBase):
    search_fields = ['^first_name', 'last_name']

    def choice_label(self, choice):
        return choice.get_full_name()


autocomplete_light.register(USER_MODEL, UserAutocomplete)

```
I could not maintain compatibility with django <1.6. I accept suggestions for how to do this

