### PR TITLE
tests reqs: pin pytest-django==2.8.0

### DIFF
--- a/test_project/test_requirements_without_django.txt
+++ b/test_project/test_requirements_without_django.txt
@@ -5,4 +5,4 @@ selenium
 lxml
 cssselect
 pytest
-pytest-django
+pytest-django==2.8.0


### PR DESCRIPTION
Ref: https://github.com/yourlabs/django-autocomplete-light/pull/501#issuecomment-145834714