### PR TITLE
Fix Django 1.9 import error

### DIFF
--- a/autocomplete_light/urls.py
+++ b/autocomplete_light/urls.py
@@ -13,11 +13,14 @@ from django import VERSION
 
 from .views import AutocompleteView, RegistryView
 
-try:
-    from django.conf.urls import patterns, url
-except ImportError:
-    # Django < 1.5
-    from django.conf.urls.defaults import patterns, url
+if VERSION > (1, 9):
+    from django.conf.urls import url
+else:
+    try:
+        from django.conf.urls import patterns, url
+    except ImportError:
+        # Django < 1.5
+        from django.conf.urls.defaults import patterns, url
 
 urlpatterns = [
     url(r'^(?P<autocomplete>[-\w]+)/$',


### PR DESCRIPTION
This is really just a test to see if CI breaks (see closed PR https://github.com/yourlabs/django-autocomplete-light/pull/501).