### PR TITLE
tests reqs: pin pytest-django==2.9.1

### DIFF
--- a/test_project/test_requirements_without_django.txt
+++ b/test_project/test_requirements_without_django.txt
@@ -5,4 +5,4 @@ selenium
 lxml==3.4.4
 cssselect
 pytest
-pytest-django==2.8.0
+pytest-django==2.9.1


### PR DESCRIPTION
Could be unpinned again, but it makes sense to not break tests because
of that in the future.

If you agree, other deps could be pinned also?!
