### PR TITLE
Py2.7: use new style classes

### DIFF
--- a/autocomplete_light/tests/test_widget.py
+++ b/autocomplete_light/tests/test_widget.py
@@ -51,7 +51,7 @@ else:
 
 
 # Global Selenium instance.
-class Selenium():
+class Selenium(object):
     selenium = None
 
     def __new__(cls):


### PR DESCRIPTION
Else, it fails as such::

    self = <autocomplete_light.tests.test_dependent.DependentAutocompleteEmptyFormTestCase testMethod=test_alpes_in_france>

        def set_implicit_wait(self):
    >       self.selenium.implicitly_wait(WAIT_TIME)
    E       AttributeError: Selenium instance has no attribute 'implicitly_wait'