### PR TITLE
Prevent travis from testing branches twice.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 language: python
+branches:
+  only:
+    - master
 matrix:
   allow_failures:
     - env: TOXENV=py27-djangomaster


### PR DESCRIPTION
::

    23:50 -!- Irssi: Join to #travis was synced in 1 secs
    23:51 < is_null> hi all, is there any way i can prevent travis from testing my
                     branches twice when they are used for a PR ? ie.
    https://github.com/yourlabs/django-autocomplete-light/pull/508#partial-pull-merging
    23:52 < jhass> branches: only: - master