### PR TITLE
Corrected french translation for "widgets.py:82"

### DIFF
--- a/autocomplete_light/locale/fr/LC_MESSAGES/django.po
+++ b/autocomplete_light/locale/fr/LC_MESSAGES/django.po
@@ -25,7 +25,7 @@ msgstr ""
 
 #: widgets.py:82
 msgid "type some text to search in this autocomplete"
-msgstr "saisissez votre rechercher dans cette autocompletion"
+msgstr "saisissez votre recherche dans ce champ"
 
 #: autocomplete/base.py:107
 msgid "no matches found"


### PR DESCRIPTION
- "votre recherche" instead of "votre rechercher".
- "dans cette autocomplétion" does not sound really goud. It would be better to say "dans ce champ de saisie automatique". However "dans ce champ" sufficient and sounds better.