### PR TITLE
Pin lxml to the last know-to-work version for pypy.

### DIFF
--- a/test_project/test_requirements_without_django.txt
+++ b/test_project/test_requirements_without_django.txt
@@ -2,7 +2,7 @@
 -r requirements_without_django.txt
 mock
 selenium
-lxml
+lxml==3.4.4
 cssselect
 pytest
 pytest-django==2.8.0


### PR DESCRIPTION
lxml is only used by autocomplete-light for tests. With version 3.4.4,
it works on PyPy:

https://travis-ci.org/yourlabs/django-autocomplete-light/jobs/87731272

But with 3.5.0 it fails:

https://travis-ci.org/yourlabs/django-autocomplete-light/jobs/91219833