### PR TITLE
Make sed command OS X/BSD-compatible

### DIFF
--- a/README
+++ b/README
@@ -20,7 +20,7 @@ DAL has been ready for Django 1.9 since April 2015 thanks to @blueyed & @jpic.
 **HOWEVER** due to the app loading refactor in 1.9 you should apply the
 following::
 
-    find . -name '*py' | xargs sed -i 's/import autocomplete_light/from autocomplete_light import shortcuts as autocomplete_light/'
+    find . -name '*.py' | xargs perl -i -pe 's/import autocomplete_light/from autocomplete_light import shortcuts as autocomplete_light/'
 
 See the test_project running on Django 1.9 and its new cool admin theme:
 http://dal-yourlabs.rhcloud.com/admin (test:test).


### PR DESCRIPTION
The `sed` command in the README for upgrading projects to Django 1.9 does not work on OS X and gives the following error, for example:

    sed: 1: "./__init__.py": invalid command code .

This is because [OS X uses BSD `sed` which either requires `''` after the `-i` if there is no backup file extension](http://stackoverflow.com/a/16746032/996114) ~~or the use of `-e`. I used `-e` in the PR, because I think it looks cleaner than having extra quotes, but the following change also works:~~

    find . -name '*py' | xargs sed -i '' 's/import autocomplete_light/from autocomplete_light import shortcuts as autocomplete_light/'

**Update:** I've actually switched the PR to use the `... sed -i '' ...` approach, because the original approach I used created unintended backup files with a suffix of `-e`.
