### PR TITLE
Update tutorial.rst

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -136,7 +136,7 @@ such:
 
     class OrderAdmin(admin.ModelAdmin):
         # This will generate a ModelForm
-        form = autocomplete_light.modelform_factory(Order)
+        form = autocomplete_light.modelform_factory(Order, fields='__all__')
     admin.site.register(Order)
 
 Refer to the :doc:`form` documentation for other ways of making forms, it is


### PR DESCRIPTION
For somebody following the quickstart, the existing example will not work for Django >= 1.8 - this is explained if you click further into the docs but that kind of defeats the point of a quickstart, so it's good to have the information upfront.