### PR TITLE
Use error_messages on FieldBase to allow overrides

### DIFF
--- a/autocomplete_light/fields.py
+++ b/autocomplete_light/fields.py
@@ -14,6 +14,10 @@ __all__ = ['FieldBase', 'ChoiceField', 'MultipleChoiceField',
 
 
 class FieldBase(object):
+    default_error_messages = {
+        'invalid': '%(autocomplete)s cannot validate %(value)s',
+    }
+
     def __init__(self, autocomplete=None, registry=None, widget=None,
             widget_js_attributes=None, autocomplete_js_attributes=None,
             extra_context=None, *args, **kwargs):
@@ -59,8 +63,12 @@ class FieldBase(object):
         values = self.prepare_value(value)
 
         if value and not self.autocomplete(values=values).validate_values():
-            raise forms.ValidationError('%s cannot validate %s' % (
-                self.autocomplete.__name__, value))
+            error_params = {
+                'autocomplete': self.autocomplete.__name__, 'value': value
+            }
+
+            raise forms.ValidationError(self.error_messages['invalid'],
+                                        code='invalid', params=error_params)
 
 
 class ChoiceField(FieldBase, forms.ChoiceField):


### PR DESCRIPTION
This PR lets you override the error message for failure to validate by passing error_messages when instantiating fields such as:

```
foo = autocomplete_light.fields.ChoiceField(autocomplete="FooAutocomplete", label="Foo", error_messages={'invalid': "Check your foo"})
```

I have not tested it, but it should also enable:

```
class BarModelForm(autocomplete_light.ModelForm):
    class Meta:
        model = Bar
        error_messages = {
            'foo': {
                'invalid': "Check your foo"
            }
        }
```