### PR TITLE
ModelChoiceField requires the queryset argument

### DIFF
--- a/autocomplete_light/exceptions.py
+++ b/autocomplete_light/exceptions.py
@@ -33,3 +33,15 @@ class NoGenericAutocompleteRegistered(AutocompleteLightException):
     def __init__(self, registry):
         msg = 'No generic autocomplete was registered.'
         super(NoGenericAutocompleteRegistered, self).__init__(msg)
+
+
+class AutocompleteChoicesMustBeQuerySet(AutocompleteLightException):
+    """
+    Raised by FieldBase constructor when used in conjunction with
+    Model(Multiple)ChoiceField given an Autocomplete class which doesn't have a
+    QuerySet for the choices attribute.
+    """
+    def __init__(self, autocomplete):
+        msg = ('%s.choices must be a QuerySet to support ModelChoiceField' %
+            autocomplete)
+        super(AutocompleteChoicesMustBeQuerySet, self).__init__(msg)

--- a/autocomplete_light/fields.py
+++ b/autocomplete_light/fields.py
@@ -7,6 +7,7 @@ from django.db.models.query import QuerySet
 
 from .registry import registry as default_registry
 from .widgets import ChoiceWidget, MultipleChoiceWidget
+from .exceptions import AutocompleteChoicesMustBeQuerySet
 
 __all__ = ['FieldBase', 'ChoiceField', 'MultipleChoiceField',
     'ModelChoiceField', 'ModelMultipleChoiceField', 'GenericModelChoiceField',
@@ -30,9 +31,11 @@ class FieldBase(object):
         # Does the subclass have ModelChoiceField or ModelMultipleChoiceField
         # as a base class?
         parents = type(self).__mro__
-        if ((forms.ModelChoiceField in parents or
-                forms.ModelMultipleChoiceField in parents) and
-                isinstance(self.autocomplete.choices, QuerySet)):
+        if (forms.ModelChoiceField in parents or
+                forms.ModelMultipleChoiceField in parents):
+
+            if not isinstance(self.autocomplete.choices, QuerySet):
+                raise AutocompleteChoicesMustBeQuerySet(self.autocomplete)
             kwargs['queryset'] = self.autocomplete.choices
 
         super(FieldBase, self).__init__(*args, **kwargs)

--- a/autocomplete_light/shortcuts.py
+++ b/autocomplete_light/shortcuts.py
@@ -1,6 +1,7 @@
 from .autocomplete.shortcuts import *
 from .contrib.taggit_field import TaggitField, TaggitWidget
 from .exceptions import (AutocompleteArgNotUnderstood,
+                         AutocompleteChoicesMustBeQuerySet,
                          AutocompleteLightException, AutocompleteNotRegistered,
                          NoGenericAutocompleteRegistered)
 from .fields import *

--- a/autocomplete_light/tests/test_fields.py
+++ b/autocomplete_light/tests/test_fields.py
@@ -73,6 +73,13 @@ class ModelChoiceFieldTestCase(BaseMixin, TestCase):
         self.assertEqual(list(test.choices),
                          [('', '---------'), (1, 'public'), (3, 'linked')])
 
+    def test_non_queryset_choices_fails(self):
+        class FailAutocomplete(autocomplete_light.AutocompleteModelBase):
+            choices = 'bar'
+
+        with self.assertRaises(autocomplete_light.AutocompleteChoicesMustBeQuerySet):
+            test = self.field_class(FailAutocomplete)
+
 
 class ModelMultipleChoiceFieldTestCase(ModelChoiceFieldTestCase):
     field_class = autocomplete_light.ModelMultipleChoiceField


### PR DESCRIPTION
Django raises an exception if the queryset argument is not passed, this
patch makes it a bit easier to understand for the user.