### PR TITLE
Stop testing Django < 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ env:
   - PIP_DISABLE_PIP_VERSION_CHECK=true
   - EXTRAREQ="codecov"
   matrix:
-  - TOXENV=py27-django14-taggit-genericm2m
-  - TOXENV=py27-django15-taggit-genericm2m
   - TOXENV=py27-django16-taggit-genericm2m
   - TOXENV=py27-django17-taggit-genericm2m
   - TOXENV=py27-django18-taggit-genericm2m-postgresql
@@ -29,7 +27,6 @@ env:
   - TOXENV=py27-django18-genericm2m
   - TOXENV=py27-django19 TESTS_SKIP_LIVESERVER=
   - TOXENV=py27-djangomaster
-  - TOXENV=py34-django15-taggit-genericm2m
   - TOXENV=py34-django16-taggit-genericm2m
   - TOXENV=py34-django17-taggit-genericm2m
   - TOXENV=py34-django18

--- a/README
+++ b/README
@@ -38,7 +38,7 @@ Features include:
   hidden far down in the scope anywhere.
 - add-another popup supported outside the admin too.
 - keyboard is supported with enter, tab and arrows by default.
-- Django 1.8, Python3 support
+- Django 1.6 to 1.10, PyPy, Python 2 and 3, PostgreSQL, SQLite, MySQL
 
 Each feature has a live example and is fully documented. It is also designed
 and documented so that you create your own awesome features too.


### PR DESCRIPTION
Unlocks a couple of pull requests. Note that Django 1.6 and 1.7 are
deprecated already and that they no long receive security updates.