### PR TITLE
fixed loading of jquery if django version os jquery is not present

### DIFF
--- a/src/dal/static/autocomplete_light/jquery.init.js
+++ b/src/dal/static/autocomplete_light/jquery.init.js
@@ -1,8 +1,8 @@
 var yl = yl || {};
 
 if (yl.jQuery === undefined) {
-    if (django.jQuery !== undefined)
-        yl.jQuery = django.jQuery
+    if (typeof django !== 'undefined')
+        yl.jQuery = django.jQuery;
 
     else if ($ !== undefined)
         yl.jQuery = $;


### PR DESCRIPTION
The check if django jquery is available which resulted in a reference error if not in the django admin.
Plus added a missing statement end: `;`.