### PR TITLE
Fix #628: Do not rely on ids to fix container text

### DIFF
--- a/src/dal_contenttypes/fields.py
+++ b/src/dal_contenttypes/fields.py
@@ -1,6 +1,7 @@
 """Model choice fields that take a ContentType too: for generic relations."""
 
 from django.contrib.contenttypes.models import ContentType
+from django.utils import six
 
 
 class ContentTypeModelFieldMixin(object):
@@ -20,6 +21,11 @@ class ContentTypeModelFieldMixin(object):
         """Return a ctypeid-objpk string for value."""
         if not value:
             return ''
+
+        if isinstance(value, six.string_types):
+            # Apparently Django's ModelChoiceField also expects two kinds of
+            # "value" to be passed in this method.
+            return value
 
         return '%s-%s' % (ContentType.objects.get_for_model(value).pk,
                           value.pk)

--- a/test_project/select2_generic_foreign_key/test_functional.py
+++ b/test_project/select2_generic_foreign_key/test_functional.py
@@ -21,13 +21,19 @@ class AdminGenericForeignKeyTestCase(Select2Story, case.AdminMixin,
         option, ctype = self.create_option()
         story = stories.SelectOption(self)
         story.select_option(option.name)
-        story.assert_value('%s-%s' % (ctype.pk, option.pk))
+        story.assert_selection_persists(
+            '%s-%s' % (ctype.pk, option.pk),
+            option.name
+        )
 
     def test_can_select_option_in_first_inline(self):
         option, ctype = self.create_option()
         story = stories.InlineSelectOption(self, inline_number=0)
         story.select_option(option.name)
-        story.assert_value('%s-%s' % (ctype.pk, option.pk))
+        story.assert_selection_persists(
+            '%s-%s' % (ctype.pk, option.pk),
+            option.name
+        )
 
     def test_can_select_option_in_first_extra_inline(self):
         option, ctype = self.create_option()


### PR DESCRIPTION
However, don't let this commit fool you into thinking having duplicate
element ids in your DOM is a good thing !