### PR TITLE
Bugfix: Taggit select2 widget in invalid forms

### DIFF
--- a/src/dal/test/stories.py
+++ b/src/dal/test/stories.py
@@ -204,8 +204,8 @@ class InlineSelectOption(SelectOption):
 
         super(InlineSelectOption, self).__init__(case, **kwargs)
 
-        self.field_container_selector = '#%s-%s' % (
-            self.inline_related_name, self.inline_number)
+        self.field_container_selector = '#%s-%s .field-%s' % (
+            self.inline_related_name, self.inline_number, self.field_name)
         self.field_selector = '#id_%s-%s-%s' % (
             self.inline_related_name,
             self.inline_number,
@@ -353,3 +353,22 @@ class CreateOptionMultiple(MultipleMixin, CreateOption):
 
 class SelectOptionMultiple(MultipleMixin, SelectOption):
     """Multiple version of CreateOptions."""
+
+
+class InlineSelectOptionMultiple(MultipleMixin, InlineSelectOption):
+    """Multiple options for InlineSelectOption."""
+
+    def __init__(self, case, inline_number, inline_related_name=None,
+                 **kwargs):
+        """Set input_selector with field_container_selector."""
+        super(InlineSelectOptionMultiple, self).__init__(
+            case,
+            inline_number,
+            inline_related_name=inline_related_name,
+            **kwargs
+        )
+
+        self.input_selector = '%s %s' % (
+            self.field_container_selector,
+            self.input_selector,
+        )

--- a/src/dal_select2_taggit/widgets.py
+++ b/src/dal_select2_taggit/widgets.py
@@ -3,6 +3,7 @@
 from dal_select2.widgets import TagSelect2
 
 from django import VERSION
+from django.utils import six
 
 
 class TaggitSelect2(TagSelect2):
@@ -11,13 +12,18 @@ class TaggitSelect2(TagSelect2):
     def render_options(self, *args):
         """Render only selected tags."""
         selected_choices_arg = 1 if VERSION < (1, 10) else 0
+        selected_choices = args[selected_choices_arg]
 
-        # Filter out None values, not needed for autocomplete
-        selected_choices = [c for c in args[selected_choices_arg] if c]
+        # When the data hasn't validated, we get the raw input here
+        if isinstance(selected_choices, six.text_type):
+            choices = [c.strip() for c in selected_choices.split(',')]
+        else:
+            # Filter out None values, not needed for autocomplete
+            choices = [c.tag.name for c in selected_choices if c]
 
         options = [
             '<option value="%s" selected="selected">%s</option>' % (
-                c.tag.name, c.tag.name) for c in selected_choices
+                c, c) for c in choices
         ]
 
         return '\n'.join(options)

--- a/test_project/select2_taggit/test_functional.py
+++ b/test_project/select2_taggit/test_functional.py
@@ -13,24 +13,33 @@ class TagSelect2AdminTestMixin(Select2Story, case.AdminMixin):
         self.get(url=self.get_modeladmin_url('add'))
         self.fill_name()
 
+        self.labels = [self.id() + '0', self.id() + '1']
+        self.tag_model.objects.create(name=self.labels[0])
+
     def test_can_select_options(self):
-        labels = [self.id() + '0', self.id() + '1']
-        self.tag_model.objects.create(name=labels[0])
         story = stories.SelectOptionMultiple(self)
 
-        for option in labels:
+        for option in self.labels:
             story.select_option(option)
 
         # assert it works with new tags
-        story.assert_labels(labels)
-        story.assert_values([labels[0], labels[1]])
+        story.assert_labels(self.labels)
+        story.assert_values([self.labels[0], self.labels[1]])
 
         # assert tags were saved, they have a pk
         story.submit()
-        story.assert_labels(labels)
+        story.assert_labels(self.labels)
 
         # With tags, values are labels
-        story.assert_values(labels)
+        story.assert_values(self.labels)
+
+    def test_can_select_option_in_first_inline(self):
+        story = stories.InlineSelectOptionMultiple(self, inline_number=0)
+
+        for option in self.labels:
+            story.select_option(option)
+
+        story.assert_selection_persists(self.labels, self.labels)
 
 
 class TaggitSelect2AdminTest(TagSelect2AdminTestMixin,


### PR DESCRIPTION
Related commit (same for dal_select2_tagging): 47db6f0f

Thanks @dan_intro for reporting on IRC !