### PR TITLE
No need to use -e

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -8,9 +8,9 @@ Install version 3 with :pip:ref:`pip install`::
 
     pip install django-autocomplete-light
 
-Or, install the dev version with git::
+Or, install the dev version from Github::
 
-    pip install -e git+https://github.com/yourlabs/django-autocomplete-light.git#egg=django-autocomplete-light
+    pip install https://github.com/yourlabs/django-autocomplete-light/archive/master.zip
 
 Then, let Django find static file we need by adding to
 :django:setting:`INSTALLED_APPS`, **before** ``django.contrib.admin``::


### PR DESCRIPTION
No need to use -e if all you need is to install Git master. It's an extra bit of complexity and can cause problems that a normal pip install wouldn't.