### PR TITLE
Prefix support in forward feature

### DIFF
--- a/src/dal/test/stories.py
+++ b/src/dal/test/stories.py
@@ -216,8 +216,7 @@ class InlineSelectOption(SelectOption):
             self.field_name
         )
 
-    def select_option(self, text):
-        """Ensure the inline is displayed before calling parent method."""
+        # Ensure the inline is displayed else click to add it
         num = len(self.case.browser.find_by_css(
             '.dynamic-%s' % self.inline_related_name))
 
@@ -225,8 +224,6 @@ class InlineSelectOption(SelectOption):
         while num < self.inline_number + 1:
             add.click()
             num += 1
-
-        super(InlineSelectOption, self).select_option(text)
 
 
 class RenameOption(SelectOption):

--- a/src/dal_select2/static/autocomplete_light/select2.js
+++ b/src/dal_select2/static/autocomplete_light/select2.js
@@ -25,11 +25,26 @@
 
                     var forward = element.attr('data-autocomplete-light-forward');
                     if (forward !== undefined) {
-                        var data_forward = {};
                         forward = forward.split(',');
 
+                        var parts = element.attr('name').split('-');
+                        var prefix = '';
+
+                        for (var i in parts) {
+                            var test_prefix = parts.slice(0, i).join('-');
+                            if (! test_prefix.length) continue;
+                            test_prefix += '-';
+
+                            if ($(':input[name=' + test_prefix + forward[0] + ']').length) {
+                                var prefix = test_prefix;
+                            }
+                        }
+
+                        var data_forward = {};
+
                         for (var key in forward) {
-                            data_forward[forward[key]] = $('[name=' + forward[key] + ']').val();
+                            var name = prefix + forward[key];
+                            data_forward[forward[key]] = $('[name=' + name + ']').val();
                         }
 
                         data.forward = JSON.stringify(data_forward);

--- a/test_project/linked_data/test_functional.py
+++ b/test_project/linked_data/test_functional.py
@@ -22,17 +22,24 @@ class AdminLinkedDataTest(Select2Story,
             self.fixtures.install_fixtures(self.model)
 
         self.get(url=self.get_modeladmin_url('add'))
+        self.prefix = ''
 
-    def test_filter_options(self):
-        story = stories.SelectOption(self)
+    def set_owner(self, value):
+        self.browser.execute_script(
+            '$("[name=%s]").val(%s)' % (self.prefix + 'owner', value)
+        )
+
+    def test_filter_options(self, story=None):
+        if story is None:
+            story = stories.SelectOption(self)
+
         story.toggle_autocomplete()
 
         expected = self.model.objects.values_list('name', flat=True)
         self.assertEqual(sorted(expected),
                          sorted(story.get_suggestions_labels()))
 
-        self.browser.execute_script('$("[name=owner]").val(%s)' %
-                                    self.fixtures.test.pk)
+        self.set_owner(self.fixtures.test.pk)
         story.refresh_autocomplete()
 
         expected = self.model.objects.filter(
@@ -40,11 +47,20 @@ class AdminLinkedDataTest(Select2Story,
         self.assertEqual(sorted(expected),
                          sorted(story.get_suggestions_labels()))
 
-        self.browser.execute_script('$("[name=owner]").val(%s)' %
-                                    self.fixtures.other.pk)
+        self.set_owner(self.fixtures.other.pk)
         story.refresh_autocomplete()
 
         expected = self.model.objects.filter(
             owner=self.fixtures.other).values_list('name', flat=True)
         self.assertEqual(sorted(expected),
                          sorted(story.get_suggestions_labels()))
+
+    def test_filter_option_in_first_inline(self):
+        self.prefix = '%s-%s-' % (self.inline_related_name, 0)
+        story = stories.InlineSelectOption(self, inline_number=0)
+        self.test_filter_options(story)
+
+    def test_can_select_option_in_first_extra_inline(self):
+        story = stories.InlineSelectOption(self, inline_number=3)
+        self.prefix = '%s-%s-' % (self.inline_related_name, 3)
+        self.test_filter_options(story)


### PR DESCRIPTION
Django forms may have a prefix, in which case all inputs of this form
will have the prefix in front of their name. It is used for example to
have 2 different forms on the same page and for formsets.