### PR TITLE
Only show the Create option if the user has permissions to create.

### DIFF
--- a/src/dal_select2/views.py
+++ b/src/dal_select2/views.py
@@ -24,7 +24,8 @@ class Select2ViewMixin(object):
         create_option = []
 
         q = self.request.GET.get('q', None)
-        if self.create_field and q and context['page_obj'].number == 1:
+        if (self.create_field and q and context['page_obj'].number == 1 and
+                self.has_add_permission(self.request)):
             create_option = [{
                 'id': q,
                 'text': 'Create "%s"' % q,


### PR DESCRIPTION
I think there is pretty much no reason for not doing this.

This prevents the "Create" option from showing on the browser if the user has no permissions for creating.

I personally have it different:

```
    def exact_result_exists(self, q):
        return self.get_queryset().filter(name=q).exists()

    def render_to_response(self, context):
        create_option = []

        q = self.request.GET.get('q', None)
        if (self.create_field and q and context['page_obj'].number == 1 and
                self.has_add_permission(self.request) and
                not self.exact_result_exists(q)):
            create_option = [{
                'id': q,
                'text': 'Create "%s"' % q,
                'create_id': True,
            }]

        return HttpResponse(
            json.dumps({
                'results': self.get_results(context) + create_option,
                'pagination': {
                    'more': self.has_more(context)
                }
            }),
            content_type='application/json',
        )
```

Trying to make it clearer: If in the database there is ['hello', 'hello1', 'hello2'] and the user searches for 'hell', if the user has no create permissions, no create option is shown. If the user has create permissions, the three 'hello, 'hello1' and 'hello2' will show, and also the create button. However, if the user searches for 'hello', even if there is an add permission, it won't show because the exact 'hello' already exists as result.

If the exact query is not to the name attribute, just overwrite the exact_result_exists(self, q) method. has_add_permission already exists and is used for post.

Sure, the method has_add_permission is not found within the Mixin, but the Mixin always literally appears used on classes that have it.

I would propose adding also the exact_result_exists() restriction, but I understand it could break backward compatibility which is why I am not adding it on this pull request.