### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -550,7 +550,7 @@ Thanks a lot to the rc tester community
     possible, else check the form API details in the source or
     generated API documentation:
 
-    - http://django-autocomplete-light.readthedocs.org/en/v2/form.html#module-autocomplete_light.forms
+    - https://django-autocomplete-light.readthedocs.io/en/v2/form.html#module-autocomplete_light.forms
 
     New features:
 

--- a/docs/gm2m.rst
+++ b/docs/gm2m.rst
@@ -5,7 +5,7 @@ Model example
 =============
 
 Consider such a model, using `django-gm2m
-<http://django-gm2m.readthedocs.org/en/stable/>`_ to handle generic
+<https://django-gm2m.readthedocs.io/en/stable/>`_ to handle generic
 many-to-many relations:
 
 .. code-block:: python


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.