### PR TITLE
Enable HTML markup in select2 item labels

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -221,6 +221,33 @@ Ensure that jquery is loaded before ``{{ form.media }}``:
 
 .. literalinclude:: ../test_project/select2_outside_admin/templates/select2_outside_admin.html
 
+Displaying results using custom HTML
+====================================
+
+You can display custom HTML code for results by setting the ``data-html``
+attribute on your widget and overriding the view ``get_result_label()`` method
+to return HTML code.
+
+.. code-block:: python
+
+    class CountryAutocomplete(autocomplete.Select2QuerySetView):
+        def get_result_label(self, item):
+            return '<img src="flags/%s.png"> %s' % (item.name, item.name)
+
+
+    class PersonForm(forms.ModelForm):
+        class Meta:
+            widgets = {
+                'birth_country': autocomplete.ModelSelect2(
+                    url='country-autocomplete',
+                    attrs={'data-html': 'true'}
+                )
+            }
+
+
+.. note:: Take care to escape anything you put in HTML code to avoid XSS attacks
+          when displaying data that may have been input by a user!
+
 Overriding javascript code
 ==========================
 

--- a/src/dal_select2/static/autocomplete_light/select2.js
+++ b/src/dal_select2/static/autocomplete_light/select2.js
@@ -22,12 +22,25 @@
         // This widget has a clear button
         $(this).find('option[value=""]').remove();
 
+        // Templating helper
+        function template(item) {
+            if (element.attr('data-html')) {
+                var $result = $('<span>');
+                $result.html(item.text);
+                return $result;
+            } else {
+                return item.text;
+            }
+        }
+
         $(this).select2({
             tokenSeparators: element.attr('data-tags') ? [','] : null,
             debug: true,
             placeholder: '',
             minimumInputLength: 0,
             allowClear: ! $(this).is('required'),
+            templateResult: template,
+            templateSelection: template,
             ajax: {
                 url: $(this).attr('data-autocomplete-light-url'),
                 dataType: 'json',


### PR DESCRIPTION
To use:
- add the `data-html` attribute
- override `get_result_label()` to return html