### PR TITLE
improve compatibility for django 1.9

### DIFF
--- a/src/dal/static/autocomplete_light/autocomplete.init.js
+++ b/src/dal/static/autocomplete_light/autocomplete.init.js
@@ -60,7 +60,7 @@ element was cloned with data - which should be the case.
         if (document.cookie && document.cookie != '') {
             var cookies = document.cookie.split(';');
             for (var i = 0; i < cookies.length; i++) {
-                var cookie = yl.jQuery.trim(cookies[i]);
+                var cookie = $.trim(cookies[i]);
                 // Does this cookie string begin with the name we want?
                 if (cookie.substring(0, name.length + 1) == (name + '=')) {
                     cookieValue = decodeURIComponent(cookie.substring(name.length + 1));

--- a/src/dal/static/autocomplete_light/autocomplete.init.js
+++ b/src/dal/static/autocomplete_light/autocomplete.init.js
@@ -60,7 +60,7 @@ element was cloned with data - which should be the case.
         if (document.cookie && document.cookie != '') {
             var cookies = document.cookie.split(';');
             for (var i = 0; i < cookies.length; i++) {
-                var cookie = jQuery.trim(cookies[i]);
+                var cookie = yl.jQuery.trim(cookies[i]);
                 // Does this cookie string begin with the name we want?
                 if (cookie.substring(0, name.length + 1) == (name + '=')) {
                     cookieValue = decodeURIComponent(cookie.substring(name.length + 1));


### PR DESCRIPTION
django 1.9 changed  jquery.init.js file.

you can see [this](https://github.com/django/django/blob/ec4f219ecb7a5e43d0353633fac4dac42d0ee492/django/contrib/admin/static/admin/js/jquery.init.js)

the old code in release package is 
```
var django = django || {};
django.jQuery = jQuery

var yl = yl || {};
yl.jQuery = django.jQuery

// this file also prevents django.jQuery.noConflict
// there's got to be a better way ...
```
use current code will cause jQuery is undefined. it looks we have a scope error.

this PR can make our code stronger.

and I am asking why django team change this init file. if they won't plan rollback to old style. 
we have to add our jquery file. so sad.

