### PR TITLE
Added note for static files not checked - git submodule error

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -23,6 +23,11 @@ This is to override the ``jquery.init.js`` script provided by the admin, which
 sets up jQuery with ``noConflict``, making jQuery available in
 ``django.jQuery`` only and not ``$``.
 
+Note: If you are trying to install from git, please make sure you are not using
+**zip/archive** url of the repo ``django-autocomplete-light`` since it will not
+contain required submodules automatically. Otherwise these submodules will then
+need to be updated separately using ``git submodule update --init``.
+
 Install the demo project
 ------------------------
 


### PR DESCRIPTION
Added note [#709](https://github.com/yourlabs/django-autocomplete-light/issues/709)