### PR TITLE
Update select2.js

### DIFF
--- a/src/dal_select2/static/autocomplete_light/select2.js
+++ b/src/dal_select2/static/autocomplete_light/select2.js
@@ -8,8 +8,13 @@
             var data_forward = {};
 
             for (var key in forward) {
-                var name = prefix + forward[key];
-                data_forward[forward[key]] = $('[name=' + name + ']').val();
+                // First look for this field in the inline
+                var $field = $('[name=' + prefix + forward[key] + ']');
+                if (!$field.length)
+                    // As a fallback, look for it outside the inline
+                    $field = $('[name=' + forward[key] + ']');
+                if ($field.length)
+                    data_forward[forward[key]] = $field.val();
             }
 
             return JSON.stringify(data_forward);


### PR DESCRIPTION
Currently, inline forms are unable to access forward fields from the main form. By adding this fallback, inlines will prefer forward fields within their own forms but will be able to access forward fields outside of themselves (not having the inline form prefix) when no such fields are found within the inline.