### PR TITLE
Fix initial value not set when selected choices aren't strings

### DIFF
--- a/src/dal/widgets.py
+++ b/src/dal/widgets.py
@@ -68,7 +68,7 @@ class WidgetMixin(object):
         selected_choices_arg = 1 if VERSION < (1, 10) else 0
 
         # Filter out None values, not needed for autocomplete
-        selected_choices = [c for c in args[selected_choices_arg] if c]
+        selected_choices = [six.text_type(c) for c in args[selected_choices_arg] if c]
 
         if self.url:
             all_choices = copy.copy(self.choices)

--- a/src/dal/widgets.py
+++ b/src/dal/widgets.py
@@ -68,7 +68,8 @@ class WidgetMixin(object):
         selected_choices_arg = 1 if VERSION < (1, 10) else 0
 
         # Filter out None values, not needed for autocomplete
-        selected_choices = [six.text_type(c) for c in args[selected_choices_arg] if c]
+        selected_choices = [six.text_type(c) for c
+                            in args[selected_choices_arg] if c]
 
         if self.url:
             all_choices = copy.copy(self.choices)


### PR DESCRIPTION
Stringify values in selected_choices to match stringification of keys in filter_choices_to_render, so non-string types can be used as selected_choices (e.g. UUIDs)