### PR TITLE
Fix placeholder not working when URL is not given to autocomplete widget

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -183,6 +183,9 @@ Passing options to select2
         },
     )
 
+.. note:: Setting a placeholder will result in generation of an an empty
+          ``option`` tag, which select2 requires.
+
 Using autocompletes in the admin
 ================================
 

--- a/src/dal/widgets.py
+++ b/src/dal/widgets.py
@@ -33,6 +33,7 @@ class WidgetMixin(object):
         """Instanciate a widget with a URL and a list of fields to forward."""
         self.url = url
         self.forward = forward or []
+        self.placeholder = kwargs.get("attrs", {}).get("data-placeholder")
         super(WidgetMixin, self).__init__(*args, **kwargs)
 
     def build_attrs(self, *args, **kwargs):
@@ -70,14 +71,16 @@ class WidgetMixin(object):
         # Filter out None values, not needed for autocomplete
         selected_choices = [c for c in args[selected_choices_arg] if c]
 
+        all_choices = copy.copy(self.choices)
         if self.url:
-            all_choices = copy.copy(self.choices)
             self.filter_choices_to_render(selected_choices)
+        else:
+            if self.placeholder:
+                self.choices.insert(0, (None, ""))
 
         html = super(WidgetMixin, self).render_options(*args)
 
-        if self.url:
-            self.choices = all_choices
+        self.choices = all_choices
 
         return html
 

--- a/src/dal_select2/static/autocomplete_light/select2.js
+++ b/src/dal_select2/static/autocomplete_light/select2.js
@@ -24,9 +24,6 @@
     $(document).on('autocompleteLightInitialize', '[data-autocomplete-light-function=select2]', function() {
         var element = $(this);
 
-        // This widget has a clear button
-        $(this).find('option[value=""]').remove();
-
         // Templating helper
         function template(item) {
             if (element.attr('data-html')) {

--- a/test_project/tests/test_widgets.py
+++ b/test_project/tests/test_widgets.py
@@ -63,7 +63,8 @@ class Select2Test(test.TestCase):  # noqa
 
         form = Form(http.QueryDict())
         expected = '''
-<select data-autocomplete-light-function="select2" data-placeholder="Some placeholder" id="id_test" name="test">
+<select data-autocomplete-light-function="select2"\
+ data-placeholder="Some placeholder" id="id_test" name="test">
 <option value="" selected="selected"></option>
 <option value="1">A</option>
 </select>

--- a/test_project/tests/test_widgets.py
+++ b/test_project/tests/test_widgets.py
@@ -1,6 +1,7 @@
 """Test the base widget."""
 
 from dal.widgets import Select
+from dal.autocomplete import Select2
 
 from django import forms
 from django import http
@@ -43,3 +44,59 @@ class SelectTest(test.TestCase):  # noqa
         '''.strip()
 
         self.assertEquals(six.text_type(form['test'].as_widget()), expected)
+
+
+@override_settings(ROOT_URLCONF='tests.test_widgets')
+class Select2Test(test.TestCase):  # noqa
+    """Test case for the Select2 widget."""
+
+    def test_widget_renders_empty_option_with_placeholder_without_url(self):
+        """Assert that it renders an empty option, if not given a url."""
+        class Form(forms.Form):
+            test = forms.ChoiceField(
+                choices=[(1, "A")],
+                widget=Select2(attrs={
+                    "data-placeholder": "Some placeholder",
+                }),
+                required=False
+            )
+
+        form = Form(http.QueryDict())
+        expected = '''
+<select data-autocomplete-light-function="select2" data-placeholder="Some placeholder" id="id_test" name="test">
+<option value="" selected="selected"></option>
+<option value="1">A</option>
+</select>
+        '''.strip()
+        observed = six.text_type(form['test'].as_widget())
+
+        self.assertEquals(observed, expected)
+
+    def test_widget_no_empty_option_without_placeholder_without_url(self):
+        """Assert that it renders an empty option, if not given a url."""
+        class Form(forms.Form):
+            test = forms.ChoiceField(
+                choices=[(1, "A")],
+                widget=Select2(),
+                required=False
+            )
+
+        form = Form(http.QueryDict())
+        expected = '''
+<select data-autocomplete-light-function="select2" id="id_test" name="test">
+<option value="1">A</option>
+</select>
+        '''.strip()
+        observed = six.text_type(form['test'].as_widget())
+
+        self.assertEquals(observed, expected)
+
+        form = Form(http.QueryDict('test=1'))
+        expected = '''
+<select data-autocomplete-light-function="select2" id="id_test" name="test">
+<option value="1" selected="selected">A</option>
+</select>
+        '''.strip()
+        observed = six.text_type(form['test'].as_widget())
+
+        self.assertEquals(observed, expected)

--- a/test_project/tests/test_widgets.py
+++ b/test_project/tests/test_widgets.py
@@ -1,7 +1,7 @@
 """Test the base widget."""
 
-from dal.widgets import Select
 from dal.autocomplete import Select2
+from dal.widgets import Select
 
 from django import forms
 from django import http


### PR DESCRIPTION
Correctly show an empty option tag when a placeholder is specified, which is what the select2 library expects by design, which fixes the placeholder not used when the widget is supplied with a list of choices but no external datasource URL.