### PR TITLE
Move create_option functionality into it's own method

### DIFF
--- a/src/dal_select2/views.py
+++ b/src/dal_select2/views.py
@@ -20,12 +20,9 @@ class Select2ViewMixin(object):
             } for result in context['object_list']
         ]
 
-    def render_to_response(self, context):
-        """Return a JSON response in Select2 format."""
+    def get_create_option(self, context, q):
+        """Form the correct create_option to append to results."""
         create_option = []
-
-        q = self.request.GET.get('q', None)
-
         display_create_option = False
         if self.create_field and q:
             page_obj = context.get('page_obj', None)
@@ -38,6 +35,13 @@ class Select2ViewMixin(object):
                 'text': _('Create "%(new_value)s"') % {'new_value': q},
                 'create_id': True,
             }]
+        return create_option
+
+    def render_to_response(self, context):
+        """Return a JSON response in Select2 format."""
+        q = self.request.GET.get('q', None)
+
+        create_option = self.get_create_option(context, q)
 
         return http.HttpResponse(
             json.dumps({


### PR DESCRIPTION
Main motivation was wanting to override this behaviour without touching
any other parts of render_to_response but I think this is also a clearer
way to organise the code.

Actually - in most cases all I really want to change is the wording of
the create text. How would you feel about a get_create_label(self,
queryset) method?

(example use case - I if someone enters a string with an @ in it I
create a new contact with an email address, otherwise I assume it's a
name - I'd like to make this behaviour explicit via the create label)