### PR TITLE
Select2WidgetMixin Media as a dynamic property

### DIFF
--- a/src/dal_select2/static/autocomplete_light/select2.js
+++ b/src/dal_select2/static/autocomplete_light/select2.js
@@ -51,6 +51,7 @@
             tokenSeparators: element.attr('data-tags') ? [','] : null,
             debug: true,
             placeholder: '',
+            language: element.attr('data-autocomplete-light-language'),
             minimumInputLength: 0,
             allowClear: ! $(this).is('required'),
             templateResult: template,

--- a/src/dal_select2/widgets.py
+++ b/src/dal_select2/widgets.py
@@ -9,28 +9,40 @@ from dal.widgets import (
 
 from django import forms
 from django.utils import six
+from django.utils import translation
+from django.conf import settings
 
 
 class Select2WidgetMixin(object):
     """Mixin for Select2 widgets."""
 
-    class Media:
+    def _media(self):
         """Automatically include static files for the admin."""
+        # get_language can be return None
+        lang_code = translation.get_language()
+        if lang_code:
+            lang_code = translation.to_locale(lang_code).replace('_', '-')
+        else:
+            lang_code = ''
 
-        css = {
-            'all': (
-                'autocomplete_light/vendor/select2/dist/css/select2.css',
-                'autocomplete_light/select2.css',
-            )
-        }
+        _min = '' if settings.DEBUG else 'min.'
+
+        css = (
+            'autocomplete_light/vendor/select2/dist/css/select2.{}css'.format(_min),
+            'autocomplete_light/select2.css',
+        )
         js = (
             'autocomplete_light/jquery.init.js',
             'autocomplete_light/autocomplete.init.js',
-            'autocomplete_light/vendor/select2/dist/js/select2.full.js',
+            'autocomplete_light/vendor/select2/dist/js/select2.full.{}js'.format(_min),
+            'autocomplete_light/vendor/select2/dist/js/i18n/{}.js'.format(lang_code),
             'autocomplete_light/forward.js',
             'autocomplete_light/select2.js',
         )
 
+        return forms.Media(css={'all': css}, js=js)
+
+    media = property(_media)
     autocomplete_function = 'select2'
 
 

--- a/src/dal_select2/widgets.py
+++ b/src/dal_select2/widgets.py
@@ -16,26 +16,41 @@ from django.conf import settings
 class Select2WidgetMixin(object):
     """Mixin for Select2 widgets."""
 
-    def _media(self):
-        """Automatically include static files for the admin."""
+    def build_attrs(self, *args, **kwargs):
+        attrs = super(Select2WidgetMixin, self).build_attrs(*args, **kwargs)
+        lang_code = self._get_language_code()
+        if lang_code:
+            attrs.setdefault('data-locale', lang_code)
+        return attrs
+
+    def _get_language_code(self):
         # get_language can be return None
         lang_code = translation.get_language()
         if lang_code:
             lang_code = translation.to_locale(lang_code).replace('_', '-')
-        else:
-            lang_code = ''
+        return lang_code
 
+    def _media(self):
+        """Automatically include static files for the admin."""
         _min = '' if settings.DEBUG else 'min.'
+        i18n_file = ()
+        lang_code = self._get_language_code()
 
+        if lang_code:
+            i18n_file = (
+                'autocomplete_light/vendor/select2/dist/js/i18n/{}.js'.format(
+                    lang_code),
+            )
         css = (
-            'autocomplete_light/vendor/select2/dist/css/select2.{}css'.format(_min),
+            'autocomplete_light/vendor/select2/dist/css/select2.{}css'.format(
+                _min),
             'autocomplete_light/select2.css',
         )
-        js = (
-            'autocomplete_light/jquery.init.js',
-            'autocomplete_light/autocomplete.init.js',
-            'autocomplete_light/vendor/select2/dist/js/select2.full.{}js'.format(_min),
-            'autocomplete_light/vendor/select2/dist/js/i18n/{}.js'.format(lang_code),
+        js = ('autocomplete_light/jquery.init.js',
+              'autocomplete_light/autocomplete.init.js',
+              'autocomplete_light/vendor/select2/dist/js/select2.full.{}js'.format(
+                  _min),
+              ) + i18n_file + (
             'autocomplete_light/forward.js',
             'autocomplete_light/select2.js',
         )

--- a/src/dal_select2/widgets.py
+++ b/src/dal_select2/widgets.py
@@ -20,7 +20,7 @@ class Select2WidgetMixin(object):
         attrs = super(Select2WidgetMixin, self).build_attrs(*args, **kwargs)
         lang_code = self._get_language_code()
         if lang_code:
-            attrs.setdefault('data-locale', lang_code)
+            attrs.setdefault('data-autocomplete-light-language', lang_code)
         return attrs
 
     def _get_language_code(self):


### PR DESCRIPTION
partially fixes the  issue #731.

corrects partly because, django `get_current_language` templatetag return a low case string with language code, and this value is commonly used on `html` tag, like `<html lang="pt-br">`, [see](https://github.com/django/django/blob/master/django/contrib/admin/templates/admin/base.html#L2-L3).  if html have any html tag with `lang="boo-bar-lang"` exists, select2 use the value to try load the language files.

The problem occur when the language is `pt-br`, `sr-cyrl`, `zh-cn`, `zh-tw`, because to these languages, some [i18n files of select2 is not low case](https://github.com/select2/select2/tree/master/src/js/select2/i18n), then select2 can not find the files. (`pt-BR.js`, `sr-Cyrl.js`, `zh-CN.js`, `zh-TW.js`)
