### PR TITLE
Fix jQuery not sending X-CSRFToken header

### DIFF
--- a/src/dal_select2/static/autocomplete_light/select2.js
+++ b/src/dal_select2/static/autocomplete_light/select2.js
@@ -73,8 +73,8 @@
                     text: data.id,
                     forward: get_forwards($(this))
                 },
-                beforeSend: function(xhr, settings) {
-                    xhr.setRequestHeader("X-CSRFToken", document.csrftoken);
+                headers: {
+                    'X-CSRFToken': document.csrftoken
                 },
                 success: function(data, textStatus, jqXHR ) {
                     select.append(


### PR DESCRIPTION
Apparently jQuery doesn't add the X-CSRFToken header when xhr.setRequestHeader() is used. $.ajax has a `headers` option which works. Fixes #772.