### PR TITLE
Updated 'testmodel' to 'tmodel' to match changes from: Fix tests (#784)

### DIFF
--- a/test_project/select2_tagging/migrations/0002_testmodel_test.py
+++ b/test_project/select2_tagging/migrations/0002_testmodel_test.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.AddField(
-            model_name='testmodel',
+            model_name='tmodel',
             name='test',
             field=tagging.fields.TagField(blank=True, max_length=255),
         ),


### PR DESCRIPTION
I was trying to install the demo project today and ran into an error when running Migrate. 

Looks like test_project/select2_tagging/migrations/0002_testmodel_test.py was omitted when updating the all the Test Models in an update from 6 days ago.  I fixed it locally and it's working for me.