### PR TITLE
Fix RemovedInDjango20Warning for 'reverse' imports

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -85,7 +85,7 @@ Create a :django:label:`named url<naming-url-patterns>` for the view, ie:
 Ensure that the url can be reversed, ie::
 
     ./manage.py shell
-    In [1]: from django.core.urlresolvers import reverse
+    In [1]: from django.urls import reverse
 
     In [2]: reverse('country-autocomplete')
     Out[2]: u'/country-autocomplete/'

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -85,9 +85,10 @@ Create a :django:label:`named url<naming-url-patterns>` for the view, ie:
 Ensure that the url can be reversed, ie::
 
     ./manage.py shell
-    In [1]: from django.core.urlresolvers import reverse
+    In [1]: from django.urls import reverse
+    In [2]: #older django versions: from django.core.urlresolvers import reverse
 
-    In [2]: reverse('country-autocomplete')
+    In [3]: reverse('country-autocomplete')
     Out[2]: u'/country-autocomplete/'
 
 .. danger:: As you might have noticed, we have just exposed data through a

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -85,7 +85,7 @@ Create a :django:label:`named url<naming-url-patterns>` for the view, ie:
 Ensure that the url can be reversed, ie::
 
     ./manage.py shell
-    In [1]: from django.urls import reverse
+    In [1]: from django.core.urlresolvers import reverse
 
     In [2]: reverse('country-autocomplete')
     Out[2]: u'/country-autocomplete/'

--- a/src/dal/test/case.py
+++ b/src/dal/test/case.py
@@ -6,7 +6,7 @@ import uuid
 from django import VERSION
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils import six
 
 from splinter import Browser

--- a/src/dal/test/case.py
+++ b/src/dal/test/case.py
@@ -6,7 +6,10 @@ import uuid
 from django import VERSION
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
-from django.urls import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.utils import six
 
 from splinter import Browser

--- a/src/dal/widgets.py
+++ b/src/dal/widgets.py
@@ -7,7 +7,10 @@ from dal import forward
 
 from django import VERSION
 from django import forms
-from django.urls import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.utils import six
 from django.utils.safestring import mark_safe
 

--- a/src/dal/widgets.py
+++ b/src/dal/widgets.py
@@ -7,7 +7,7 @@ from dal import forward
 
 from django import VERSION
 from django import forms
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils import six
 from django.utils.safestring import mark_safe
 

--- a/test_project/select2_generic_foreign_key/test_forms.py
+++ b/test_project/select2_generic_foreign_key/test_forms.py
@@ -3,7 +3,7 @@ from dal import autocomplete
 from django import forms
 from django import http
 from django import test
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils import six
 
 from queryset_sequence import QuerySetSequence

--- a/test_project/select2_generic_foreign_key/test_forms.py
+++ b/test_project/select2_generic_foreign_key/test_forms.py
@@ -3,7 +3,10 @@ from dal import autocomplete
 from django import forms
 from django import http
 from django import test
-from django.urls import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.utils import six
 
 from queryset_sequence import QuerySetSequence

--- a/test_project/select2_generic_m2m/test_forms.py
+++ b/test_project/select2_generic_m2m/test_forms.py
@@ -4,7 +4,10 @@ from django import forms
 from django import http
 from django import test
 from django.contrib.auth.models import Group
-from django.urls import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.utils import six
 
 from queryset_sequence import QuerySetSequence

--- a/test_project/select2_generic_m2m/test_forms.py
+++ b/test_project/select2_generic_m2m/test_forms.py
@@ -4,7 +4,7 @@ from django import forms
 from django import http
 from django import test
 from django.contrib.auth.models import Group
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils import six
 
 from queryset_sequence import QuerySetSequence

--- a/test_project/select2_outside_admin/views.py
+++ b/test_project/select2_outside_admin/views.py
@@ -1,4 +1,7 @@
-from django.urls import reverse_lazy
+try:
+    from django.urls import reverse_lazy
+except ImportError:
+    from django.core.urlresolvers import reverse_lazy
 from django.views import generic
 
 from select2_many_to_many.forms import TForm

--- a/test_project/select2_outside_admin/views.py
+++ b/test_project/select2_outside_admin/views.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse_lazy
+from django.urls import reverse_lazy
 from django.views import generic
 
 from select2_many_to_many.forms import TForm

--- a/test_project/select2_tagging/test_forms.py
+++ b/test_project/select2_tagging/test_forms.py
@@ -1,7 +1,7 @@
 from django import forms
 from django import http
 from django import test
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils import six
 
 from tagging.models import Tag

--- a/test_project/select2_tagging/test_forms.py
+++ b/test_project/select2_tagging/test_forms.py
@@ -1,7 +1,10 @@
 from django import forms
 from django import http
 from django import test
-from django.urls import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.utils import six
 
 from tagging.models import Tag

--- a/test_project/select2_taggit/test_forms.py
+++ b/test_project/select2_taggit/test_forms.py
@@ -2,7 +2,10 @@ import django
 from django import forms
 from django import http
 from django import test
-from django.urls import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.utils import six
 
 from taggit.models import Tag

--- a/test_project/select2_taggit/test_forms.py
+++ b/test_project/select2_taggit/test_forms.py
@@ -2,7 +2,7 @@ import django
 from django import forms
 from django import http
 from django import test
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils import six
 
 from taggit.models import Tag

--- a/test_project/tests/test_widgets.py
+++ b/test_project/tests/test_widgets.py
@@ -8,7 +8,10 @@ from django import forms
 from django import http
 from django import test
 from django.conf.urls import url
-from django.urls import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.test.utils import override_settings
 from django.utils import six
 

--- a/test_project/tests/test_widgets.py
+++ b/test_project/tests/test_widgets.py
@@ -8,7 +8,7 @@ from django import forms
 from django import http
 from django import test
 from django.conf.urls import url
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.utils import override_settings
 from django.utils import six
 


### PR DESCRIPTION
Hi,

I only did a search and replace for this but I don't see what could go wrong^(tm).