### PR TITLE
Fix documentation error where ListSelect2 widget is named incorrectly

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -549,11 +549,11 @@ of strings rather than a QuerySet.  This can be achieved with the
 
 This class can then be registered as in the previous example.  Suppose
 we register it under URL 'country-list-autocomplete'.  We can then a
-create a Select2List widget with:
+create a ListSelect2 widget with:
 
 .. code-block:: python
 
-    widget = autocomplete.Select2List(url='country-list-autocomplete')
+    widget = autocomplete.ListSelect2(url='country-list-autocomplete')
 
 With this in place, if a user types the letter ``f``' in the widget, choices
 'France', 'Fiji', and 'Finland' would be offered.


### PR DESCRIPTION
I was trying to follow the tutorial to create an autocomplete with a static list rather than a QuerySet and was getting errors referring to Select2List. It turns out that isn't what it's called.

This commit just updates the documentation