### PR TITLE
Return 400 on invalid input

### DIFF
--- a/test_project/linked_data/test_views.py
+++ b/test_project/linked_data/test_views.py
@@ -1,0 +1,49 @@
+"""Test the base autocomplete view."""
+
+import json
+
+from django import test
+from django.core.urlresolvers import reverse
+from django.utils.encoding import force_text
+
+from .models import TModel
+from .urls import LinkedDataView
+
+
+class ViewMixinTest(test.TestCase):  # noqa
+    """TestCase for ViewMixin data decoding."""
+
+    def setUp(self):
+        self.factory = test.RequestFactory()
+
+    def test_no_data(self):
+        request = self.factory.get(reverse('linked_data'))
+
+        response = LinkedDataView.as_view(model=TModel)(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertJSONEqual(force_text(response.content),
+                             '{"results": [], "pagination": {"more": false}}')
+
+    def test_not_dict(self):
+        request = self.factory.get(
+            reverse('linked_data') + '?forward=' + json.dumps('[]')
+        )
+
+        response = LinkedDataView.as_view(model=TModel)(request)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(force_text(response.content), 'Not a JSON object')
+
+    def test_invalid_json(self):
+        request = self.factory.get(
+            reverse('linked_data') + '?forward={]'
+        )
+
+        response = LinkedDataView.as_view(model=TModel)(request)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(force_text(response.content), 'Invalid JSON data')
+
+    def test_invalid_method(self):
+        request = self.factory.put(reverse('linked_data'))
+
+        response = LinkedDataView.as_view(model=TModel)(request)
+        self.assertEqual(response.status_code, 405)

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ setenv =
 commands =
     mysql: mysql -u root -e 'drop database if exists dal_test;'
     postgresql: psql -U postgres -c 'drop database if exists dal_test;'
-    py.test -v --cov --liveserver 127.0.0.1:9999
+    py.test -v --cov --liveserver 127.0.0.1:9999 {posargs}
 
 deps =
     django18: Django>=1.8,<1.9


### PR DESCRIPTION
A simple patch to return proper information to the client side that its input data is invalid.
This is especially useful to silence errors that are not server-side when coupled with reporting tools such as [sentry](https://sentry.io/welcome/), [Airbrake](https://airbrake.io/), etc.

I did not add unittests as I got lost in the structure for functional tests as library specific tests but if you tell me where to look, I'll add them.