### PR TITLE
rename_forward tests

### DIFF
--- a/test_project/rename_forward/test_functional.py
+++ b/test_project/rename_forward/test_functional.py
@@ -1,9 +1,10 @@
-from .models import TModel
 import linked_data.test_functional
+
+from .models import TModel
 
 
 class RenameForwardAdminLinkedDataTestTest(
-    linked_data.test_functional.AdminLinkedDataTest):
+        linked_data.test_functional.AdminLinkedDataTest):
     """Reusing functional test scenarios from linked_data app."""
 
     model = TModel

--- a/test_project/rename_forward/test_functional.py
+++ b/test_project/rename_forward/test_functional.py
@@ -1,0 +1,10 @@
+from .models import TModel
+import linked_data.test_functional
+
+
+class RenameForwardAdminLinkedDataTestTest(
+    linked_data.test_functional.AdminLinkedDataTest):
+    """Reusing functional test scenarios from linked_data app."""
+
+    model = TModel
+    inline_related_name = 'inline_test_models_rf'


### PR DESCRIPTION
I have added `test_functional` suite that reuses scenarios from `linked_data` app.

`test_forms` suite from `linked_data` seems useless for `rename_forward` app since it won't test any other functionality.

I am thinking of writing tests that checks if Select2 widget is rendered correctly, especially the forward configuration part (perhaps we can add something like that to `linked_data` app). The other good thing to test can be `LinkedDataView` to check if we're running functional tests with properly working view (the forward feature itself does not add any features to DAL views).