### PR TITLE
Queryset sequence view to display actual model name

### DIFF
--- a/src/dal_queryset_sequence/views.py
+++ b/src/dal_queryset_sequence/views.py
@@ -52,7 +52,7 @@ class BaseQuerySetSequenceView(BaseQuerySetView):
                           result.pk)
 
     def get_model_name(self, model):
-        """Return the name of the model, fetch the parent if model is a proxy"""
+        """Return the name of the model, fetch parent if model is a proxy"""
         if model._meta.proxy:
             try:
                 model = list(model._meta.parents.keys())[0]

--- a/src/dal_queryset_sequence/views.py
+++ b/src/dal_queryset_sequence/views.py
@@ -50,3 +50,12 @@ class BaseQuerySetSequenceView(BaseQuerySetView):
         """Return ctypeid-objectid for result."""
         return '%s-%s' % (ContentType.objects.get_for_model(result).pk,
                           result.pk)
+
+    def get_model_name(self, model):
+        """Return the name of the model, fetch the parent if model is a proxy"""
+        if model._meta.proxy:
+            try:
+                model = model._meta.parents.keys()[0]
+            except IndexError:
+                pass
+        return model._meta.verbose_name

--- a/src/dal_queryset_sequence/views.py
+++ b/src/dal_queryset_sequence/views.py
@@ -55,7 +55,7 @@ class BaseQuerySetSequenceView(BaseQuerySetView):
         """Return the name of the model, fetch the parent if model is a proxy"""
         if model._meta.proxy:
             try:
-                model = model._meta.parents.keys()[0]
+                model = list(model._meta.parents.keys())[0]
             except IndexError:
                 pass
         return model._meta.verbose_name

--- a/src/dal_select2_queryset_sequence/views.py
+++ b/src/dal_select2_queryset_sequence/views.py
@@ -43,9 +43,19 @@ class Select2QuerySetSequenceView(BaseQuerySetSequenceView, Select2ViewMixin):
             groups.setdefault(type(result), [])
             groups[type(result)].append(result)
 
+        def get_model_name(model):
+            # Fetch the parent model if this is a proxy
+            if model._meta.proxy:
+                try:
+                    # Fetch the proxied model instead
+                    model = model._meta.parents.keys()[0]
+                except (IndexError, ):
+                    pass
+            return model._meta.verbose_name
+
         return [{
             'id': None,
-            'text': capfirst(model._meta.verbose_name),
+            'text': capfirst(get_model_name(model)),
             'children': [{
                 'id': self.get_result_value(result),
                 'text': six.text_type(result),

--- a/src/dal_select2_queryset_sequence/views.py
+++ b/src/dal_select2_queryset_sequence/views.py
@@ -43,19 +43,9 @@ class Select2QuerySetSequenceView(BaseQuerySetSequenceView, Select2ViewMixin):
             groups.setdefault(type(result), [])
             groups[type(result)].append(result)
 
-        def get_model_name(model):
-            # Fetch the parent model if this is a proxy
-            if model._meta.proxy:
-                try:
-                    # Fetch the proxied model instead
-                    model = model._meta.parents.keys()[0]
-                except (IndexError, ):
-                    pass
-            return model._meta.verbose_name
-
         return [{
             'id': None,
-            'text': capfirst(get_model_name(model)),
+            'text': capfirst(self.get_model_name(model)),
             'children': [{
                 'id': self.get_result_value(result),
                 'text': six.text_type(result),

--- a/test_project/select2_generic_foreign_key/models.py
+++ b/test_project/select2_generic_foreign_key/models.py
@@ -32,3 +32,12 @@ class TModel(models.Model):
 
     def __str__(self):
         return self.name
+
+
+@python_2_unicode_compatible
+class TProxyModel(TModel):
+    class Meta:
+        proxy = True
+
+    def __str__(self):
+        return self.name

--- a/test_project/select2_generic_foreign_key/test_forms.py
+++ b/test_project/select2_generic_foreign_key/test_forms.py
@@ -12,7 +12,7 @@ from django.utils import six
 from queryset_sequence import QuerySetSequence
 
 from .forms import TForm
-from .models import TModel
+from .models import TModel, TProxyModel
 
 
 class GenericFormTest(test.TestCase):  # noqa
@@ -21,6 +21,11 @@ class GenericFormTest(test.TestCase):  # noqa
     def get_value(self, model):
         view = autocomplete.BaseQuerySetSequenceView
         return view.get_result_value(view(), model)
+
+    def test_model_name(self):
+        view = autocomplete.BaseQuerySetSequenceView
+        self.assertEqual(view.get_model_name(view(), TProxyModel), 't model')
+        self.assertEqual(view.get_model_name(view(), TModel), 't model')
 
     def test_save(self):
         # Create an option to select

--- a/test_project/select2_generic_foreign_key/test_forms.py
+++ b/test_project/select2_generic_foreign_key/test_forms.py
@@ -27,6 +27,13 @@ class GenericFormTest(test.TestCase):  # noqa
         self.assertEqual(view.get_model_name(view(), TProxyModel), 't model')
         self.assertEqual(view.get_model_name(view(), TModel), 't model')
 
+    def test_model_name_index_error(self):
+        view = autocomplete.BaseQuerySetSequenceView
+        # remove the parents attribute
+        TProxyModel._meta.parents = {}
+        self.assertEqual(
+            view.get_model_name(view(), TProxyModel), 't proxy model')
+
     def test_save(self):
         # Create an option to select
         fixture = TModel.objects.create(name='relation' + self.id())


### PR DESCRIPTION
The change set here uses the actual model, instead of the QuerySetSequence proxy model.

Before
![qss-before](https://cloud.githubusercontent.com/assets/23966/25242832/06d582ba-25c9-11e7-93f9-7609064e4b70.png)

After
![qss-after](https://cloud.githubusercontent.com/assets/23966/25242850/137d5fce-25c9-11e7-964a-f458bbcb09ad.png)
