### PR TITLE
Allow boolean "data-html" attribute for widget on python side.

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -245,7 +245,7 @@ to return HTML code.
             widgets = {
                 'birth_country': autocomplete.ModelSelect2(
                     url='country-autocomplete',
-                    attrs={'data-html': 'true'}
+                    attrs={'data-html': True}
                 )
             }
 

--- a/src/dal_select2/static/autocomplete_light/select2.js
+++ b/src/dal_select2/static/autocomplete_light/select2.js
@@ -52,7 +52,7 @@
 
         // Templating helper
         function template(item) {
-            if (element.attr('data-html')) {
+            if (element.attr('data-html') !== undefined) {
                 var $result = $('<span>');
                 $result.html(item.text);
                 return $result;


### PR DESCRIPTION
Now if you want custom HTML in your autocomplete widget you have to write the following code:
```python
class CountryAutocomplete(autocomplete.Select2QuerySetView):
    def get_result_label(self, item):
        return '<img src="flags/%s.png"> %s' % (item.name, item.name)


class PersonForm(forms.ModelForm):
    class Meta:
        widgets = {
            'birth_country': autocomplete.ModelSelect2(
                url='country-autocomplete',
                attrs={'data-html': 'true'}
            )
        }
```

String value "true" does not look nice. Unfortunately passing `attrs={'data-html': True}` will not enable custom HTML in options since Select2 widget is rendered as follows:
```html
<select data-html="" ... > ... </select>
```
and condition in
```javascript
if (element.attr('data-html')) {
    // ...
}
```
is false.


This fix allows to use boolean value in Python widget attributes without breaking existing client code that uses string value.