### PR TITLE
Improve 'data-html' conditional in select2.js

### DIFF
--- a/src/dal_select2/static/autocomplete_light/select2.js
+++ b/src/dal_select2/static/autocomplete_light/select2.js
@@ -60,7 +60,8 @@
 
         // Templating helper
         function template(item) {
-            if (element.attr('data-html') !== undefined) {
+            var attr = element.attr('data-html');
+            if (typeof attr !== typeof undefined && attr !== false) {
                 var $result = $('<span>');
                 $result.html(item.text);
                 return $result;


### PR DESCRIPTION
With `widget=autocomplete.ModelSelect2(attrs={"data-html": True})` an empty attribute, `data-html`, is set on the relevant html node telling the javascript to render the `get_result_label` text out as html rather than text.

However, when it comes to the test `if (element.attr('data-html') !== undefined)` the value being assessed is the empty string and so that test is **failing** and the markup we want to render is just coming out as a string, tags and all.

This diff improves that conditional so that the test passes on the empty string and the html is correctly rendered out as we would expect.
