### PR TITLE
Don't create a new option if an iexact-matching one already exists

### DIFF
--- a/src/dal_select2/views.py
+++ b/src/dal_select2/views.py
@@ -33,6 +33,10 @@ class Select2ViewMixin(object):
             if page_obj is None or page_obj.number == 1:
                 display_create_option = True
 
+            # Don't offer to create a new option if a (case-insensitive) identical one already exists
+            if self.get_queryset().filter(**{self.create_field +'__iexact': q}).exists():
+                display_create_option = False
+
         if display_create_option and self.has_add_permission(self.request):
             create_option = [{
                 'id': q,

--- a/src/dal_select2/views.py
+++ b/src/dal_select2/views.py
@@ -33,8 +33,11 @@ class Select2ViewMixin(object):
             if page_obj is None or page_obj.number == 1:
                 display_create_option = True
 
-            # Don't offer to create a new option if a (case-insensitive) identical one already exists
-            if self.get_queryset().filter(**{self.create_field +'__iexact': q}).exists():
+            # Don't offer to create a new option if a
+            # case-insensitive) identical one already exists
+            existing_options = (self.get_result_label(result).lower()
+                                for result in context['object_list'])
+            if q.lower() in existing_options:
                 display_create_option = False
 
         if display_create_option and self.has_add_permission(self.request):


### PR DESCRIPTION
# Current behaviour:

Select2 offers to create a new option even if an identical one exists (and if you click on it, it will actually create a duplicate in your database unless you've set up your models to prevent duplicates)

![image](https://cloud.githubusercontent.com/assets/16456010/26038815/80d31652-3908-11e7-9ec0-f3681f2b2740.png)

# Desired behaviour:

Select2 doesn't offer to create a new option if an identical one exists

![image](https://cloud.githubusercontent.com/assets/16456010/26038793/3b13ece0-3908-11e7-8030-eff77c436737.png)

Or if a case-insensitive match exists

![image](https://cloud.githubusercontent.com/assets/16456010/26038800/482735f4-3908-11e7-93b3-e55111219954.png)

Only offer to create a new option if an exact match doesn't exist

![image](https://cloud.githubusercontent.com/assets/16456010/26038809/68617dac-3908-11e7-83ef-89f172dea26b.png)

# Notes

Probably also need to do something similar in `Select2ListView.get()`