### PR TITLE
dal: widgets: use the name if we don't have the id

### DIFF
--- a/src/dal/widgets.py
+++ b/src/dal/widgets.py
@@ -147,8 +147,12 @@ class WidgetMixin(object):
 
     def render(self, name, value, attrs=None):
         """Calling Django render together with `render_forward_conf`."""
+        try:
+            field_id = attrs['id']
+        except (KeyError, TypeError):
+            field_id = name
         widget = super(WidgetMixin, self).render(name, value, attrs)
-        conf = self.render_forward_conf(attrs['id'])
+        conf = self.render_forward_conf(field_id)
         return mark_safe(widget + conf)
 
     def _get_url(self):

--- a/test_project/tests/test_widgets.py
+++ b/test_project/tests/test_widgets.py
@@ -1,7 +1,7 @@
 """Test the base widget."""
 
 from dal.autocomplete import Select2
-from dal.widgets import Select
+from dal.widgets import Select, WidgetMixin
 
 import django
 from django import forms
@@ -109,3 +109,31 @@ class Select2Test(test.TestCase):  # noqa
         observed = six.text_type(form['test'].as_widget())
 
         self.assertHTMLEqual(observed, expected)
+
+
+@override_settings(ROOT_URLCONF='tests.test_widgets')
+class WidgetMixinTest(test.TestCase):  # noqa
+    def test_widget_renders_without_attrs(self):
+        """Assert that render will fallback to field name if id not available"""
+
+        class BaseWidget(object):
+            def render(self, name, value, attrs=None):
+                return ''
+
+        class Widget(WidgetMixin, BaseWidget):
+            def render_forward_conf(self, id):
+                return six.text_type(id)
+
+        widget = Widget(forward=['test'])
+
+        # no attrs
+        observed = widget.render('myname', '')
+        self.assertEqual(observed,'myname' )
+
+        # attrs without id
+        observed = widget.render('myname', '', attrs={})
+        self.assertEqual(observed, 'myname')
+
+        # attrs with id
+        observed = widget.render('myname', '', attrs={'id': 'myid'})
+        self.assertEqual(observed, 'myid')


### PR DESCRIPTION
On a fairly involved configuration where my admin
is using django-mptt-admin and dal_admin_filters and so
django-autocomplete-light it happens that the rendered
widget has no attrs.

```
File "/venv/src/django_mptt_admin/admin.py" in get_queryset
  361. self.filter_specs, self.has_filters, remaining_lookup_params, filters_use_distinct = self.get_filters(request)

File "/venv/src/django/contrib/admin/views/main.py" in get_filters
  114. spec = list_filter(request, lookup_params, self.model, self.model_admin)

File "/venv/src/dal_admin_filters/__init__.py" in __init__
  48.  name=self.parameter_name, value=self.used_parameters.get(self.parameter_name, '')

File "/venv/src/django-autocomplete-light/src/dal/widgets.py" in render
  151. conf = self.render_forward_conf(attrs['id'])

Exception Value: 'NoneType' object has no attribute '__getitem__'
```

To workaround that if we don't have attrs we can use the name instead.