### PR TITLE
dal: prefer pristine jQuery to the django one

### DIFF
--- a/src/dal/static/autocomplete_light/jquery.init.js
+++ b/src/dal/static/autocomplete_light/jquery.init.js
@@ -1,9 +1,9 @@
 var yl = yl || {};
 
 if (yl.jQuery === undefined) {
-    if ((typeof django !== 'undefined') && (typeof django.jQuery !== 'undefined'))
-        yl.jQuery = django.jQuery;
-
-    else if (typeof $ !== 'undefined')
+    /* If the user has included another copy of jQuery use that, even in the admin */
+    if (typeof $ !== 'undefined')
         yl.jQuery = $;
+    else if ((typeof django !== 'undefined') && (typeof django.jQuery !== 'undefined'))
+        yl.jQuery = django.jQuery;
 }


### PR DESCRIPTION
First of all i can't see how select2 may work without a jQuery
as a global $. Said that now when i have another copy of jQuery
on top of the django one, select2 will register to $ but dal
will set yl.jQuery to the django one instead.
If we prefer using $ instead they'll both use the same jQuery
instance and magically work.
If there's not jQuery loaded as $ the code will behave as before.
This makes dal working reliably in the admin for me.