### PR TITLE
Fetch csrftoken from DOM when not found via cookie

### DIFF
--- a/src/dal/static/autocomplete_light/autocomplete.init.js
+++ b/src/dal/static/autocomplete_light/autocomplete.init.js
@@ -75,4 +75,11 @@ element was cloned with data - which should be the case.
     }
 
     document.csrftoken = getCookie('csrftoken');
+    if (document.csrftoken === null) {
+        // Try to get CSRF token from DOM when cookie is missing
+        var $csrf = $('form :input[name="csrfmiddlewaretoken"]');
+        if ($csrf.length > 0) {
+            document.csrftoken = $csrf[0].value;
+        }
+    }
 })(yl.jQuery);


### PR DESCRIPTION
Look for a csrfmiddlewaretoken input in a form on the page when the
csrftoken cookie is not present. This is commonly caused by
a CSRF_COOKIE_HTTPONLY = True setting for the app.

Closes: #772