### PR TITLE
Fix selector used to allow clearing non-required fields.

### DIFF
--- a/src/dal_select2/static/autocomplete_light/select2.js
+++ b/src/dal_select2/static/autocomplete_light/select2.js
@@ -104,7 +104,7 @@
             debug: true,
             placeholder: '',
             minimumInputLength: 0,
-            allowClear: ! $(this).is('required'),
+            allowClear: ! $(this).is('[required]'),
             templateResult: template,
             templateSelection: template,
             ajax: ajax,


### PR DESCRIPTION
`is('required')` seems to return `false` regardless of whether the field has the `required` attribute or not. This change uses a more appropriate selector to configure select2 as clearable.