### PR TITLE
Select2 url mutable

### DIFF
--- a/src/dal_select2/static/autocomplete_light/select2.js
+++ b/src/dal_select2/static/autocomplete_light/select2.js
@@ -121,7 +121,9 @@
             var select = $(this);
 
             $.ajax({
-                url: $(this).attr('data-autocomplete-light-url'),
+                url: function () {
+                    return element.attr('data-autocomplete-light-url');
+                },
                 type: 'POST',
                 dataType: 'json',
                 data: {


### PR DESCRIPTION
With the built in select2 functionality, the data-autocomplete-light-url can be read and modified dynamically.

For Example:
```javascript
var companySelect = $("select[name=company]");
var deliveryAddressSelect = $("select[name=delivery_address]");
companySelect.change(function (e) {
    var url = "/addresses/auto-complete?company_id="
        + e.target.options[e.target.selectedIndex].value;
    deliveryAddressSelect.attr("data-autocomplete-light-url", url);
});
```
If the company changes in the form, I update the query set of the addresses with the help of the query string. Like this I only get the delivery addresses possible for the given company.