### PR TITLE
Return proper content-type for reply

### DIFF
--- a/src/dal_select2/views.py
+++ b/src/dal_select2/views.py
@@ -83,7 +83,7 @@ class Select2ListView(ViewMixin, View):
                 }]
         return http.HttpResponse(json.dumps({
             'results': [dict(id=x, text=x) for x in results] + create_option
-        }))
+        }), content_type='application/json')
 
     def post(self, request):
         """"Add an option to the autocomplete list.


### PR DESCRIPTION
When running behind nginx, when the content-type is not specified, I get the JSON response nicely wrapped inside <body> tag, which will of course give an error on the web ui. 

I'm not sure how to test for this, except the obvious (checking for content-type in all the subclasses). I also wonder, if this won't break anything for someone else. Well. 

Let me know what do you think. 