### PR TITLE
Replacing call to six with call to predefined get_result_label function

### DIFF
--- a/src/dal/views.py
+++ b/src/dal/views.py
@@ -116,5 +116,5 @@ class BaseQuerySetView(ViewMixin, BaseListView):
 
         return http.JsonResponse({
             'id': result.pk,
-            'text': six.text_type(result),
+            'text': self.get_result_label(result),
         })


### PR DESCRIPTION
Addresses #879.

If a user has overridden get_result_label, a newly created object still uses the six version of the text instead of using the overridden function.