### PR TITLE
Allow overwriting the results

### DIFF
--- a/src/dal_select2/views.py
+++ b/src/dal_select2/views.py
@@ -74,7 +74,7 @@ class Select2ListView(ViewMixin, View):
         results = self.get_list()
         create_option = []
         if self.q:
-            results = [x for x in results if self.q.lower() in x.lower()]
+            results = self.autocomplete_results(results)
             if hasattr(self, 'create'):
                 create_option = [{
                     'id': self.q,
@@ -82,9 +82,17 @@ class Select2ListView(ViewMixin, View):
                     'create_id': True
                 }]
         return http.HttpResponse(json.dumps({
-            'results': [dict(id=x, text=x) for x in results] + create_option
+            'results': self.results(results) + create_option
         }))
 
+    def autocomplete_results(self, results):
+        """Return list of strings that match the autocomplete query."""
+        return [x for x in results if self.q.lower() in x.lower()]
+
+    def results(self, results):
+        """Return the result dictionary."""
+        return [dict(id=x, text=x) for x in results]
+    
     def post(self, request):
         """"Add an option to the autocomplete list.
 


### PR DESCRIPTION
Allow overwriting the autocomplete result list and the result dictionary.
Currently DAL.Select2ListView uses both the first (=id) and second item (=text) in the choice 2-tuple, which is a problem when you want to translate your select2 options, because the form choice id doesn't know about the translated choice, unlesss you use something like
django-modeltranslation, which is unnessecary in this case.

Example use case:
```
from dal import autocomplete


class LanguagesAutocomplete(autocomplete.Select2ListView):

    def autocomplete_results(self, results):
        return [x for x in results if self.q.lower() in _(x).lower() or self.q.lower() in "-" + _(x[1:]).lower()]

    def results(self, results):
        trans_results = list()
        for x in results:
            if x.startswith("-"):
                trans_results.append((x, "-" + _(x[1:])))
            else:
                trans_results.append((x, _(x)))
        return [dict(id=x, text=y) for x, y in trans_results]

    def get_list(self):
        lst1, lst2 = list(), list()
        for x in Languages.objects.all():                                                                                                                                                                                                                                    
            lst1.append(x.name)
            lst2.append("-%s" % x.name)
        lst = sorted(lst1) + sorted(lst2)
        return lst
```