### PR TITLE
Prevent rendering of empty option on multi select

### DIFF
--- a/src/dal/widgets.py
+++ b/src/dal/widgets.py
@@ -138,7 +138,7 @@ class WidgetMixin(object):
         all_choices = copy.copy(self.choices)
         if self.url:
             self.filter_choices_to_render(selected_choices)
-        else:
+        elif not self.allow_multiple_selected:
             if self.placeholder:
                 self.choices.insert(0, (None, ""))
         result = super(WidgetMixin, self).optgroups(name, value, attrs)


### PR DESCRIPTION
Fixes: Select2Multiple adds empty choice #825 for Django >1.10
See also PR #826