### PR TITLE
simple model autocomplete - initial draft

### DIFF
--- a/src/dal_select2/views.py
+++ b/src/dal_select2/views.py
@@ -4,7 +4,7 @@ import collections
 import json
 import six
 
-from dal.views import BaseQuerySetView, ViewMixin
+from dal.views import BaseQuerySetView, ViewMixin, GenericModelQuerySetView
 
 from django import http
 from django.core.exceptions import ImproperlyConfigured
@@ -60,6 +60,14 @@ class Select2ViewMixin(object):
 
 class Select2QuerySetView(Select2ViewMixin, BaseQuerySetView):
     """List options for a Select2 widget."""
+
+
+class Select2GenericModelQuerySetView(
+    Select2ViewMixin, GenericModelQuerySetView
+):
+    """Simple, generic autocomplete view based on arguments provided in the
+       urls
+    """
 
 
 class Select2ListView(ViewMixin, View):


### PR DESCRIPTION
This is an initial draft for what I call 'simple autocomplete for models'.

@jpic I would like to deeply and sincerely apologise for this insane delay. Could you please take a look at this initial draft and guide me how it should be secured / enhanced ?

Dear friend developer @EvaSDK from PR #815 - could you take a look at this as well ?

Here's a sample usage:

```
#urls.py
from django.conf.urls import url
from dal_select2.views import Select2GenericModelQuerySetView
from models import Parent # this is my model class, it contains 2 fields - first_name, last_name

urlpatterns = [
    url(r'^$', views.index),
    url(
        r'^ac',
        Select2GenericModelQuerySetView.as_view(
            model=Parent,
            search_fields=('first_name', 'last_name'),
        ),
        name='parent-ac',
    )
]

#views.py
from django.shortcuts import render
from forms import Search

# Create your views here.
def index(req):
    form = Search()

    return render(
        req,
        'foo/test.html', {
            'form': form
        }
    )

#forms.py
from django import forms
from models import Parent
from dal_select2.widgets import ModelSelect2


class Search(forms.Form):
    parent = forms.ModelChoiceField(
        queryset=Parent.objects.all(),
        widget=ModelSelect2(url='parent-ac')
    )

    class Meta:
        exclude = []

```

p.s. I tried to implement this in v2 branch as well, but I failed to see where are the views for select2 :/