### PR TITLE
More forward features

### DIFF
--- a/src/dal/forward.py
+++ b/src/dal/forward.py
@@ -94,3 +94,74 @@ class Const(Forward):
         d.update(dst=self.dst)
 
         return d
+
+
+class JavaScript(Forward):
+    """Run registered javascript handler and forward its returned value.
+
+    You can register custom forward handler in your JS code as follows:
+
+    .. code-block:: javascript
+
+    yl.registerForwardHandler("your_handler", function (autocompleteElement) {
+        // your code here
+    });
+
+    Then if your add ``JavaScript("your_handler", "some_value")`` to your
+    forwards declaration, your function will be called, autocomplete field
+    HTML element will be passed as ``autocompleteElement`` and returned value
+    will be added to forward dictionary with ``some_value`` key.
+
+    .. py:attribute:: handler
+
+    The name of the registered handler.
+
+    .. py:attribute:: dst
+
+    The name of the key of the forwarded value from the src field in the
+    forwarded dictionary. If this value is ``None``, then the key is
+    ``handler``
+    """
+
+    type = "javascript"
+
+    def __init__(self, handler, dst=None):
+        self.handler = handler
+        self.dst = dst
+
+    def to_dict(self):
+        """Convert to dictionary which will be rendered as JSON."""
+        d = super(JavaScript, self).to_dict()
+
+        d.update(handler=self.handler)
+        d.update(dst=self.dst)
+
+        return d
+
+
+class Self(Forward):
+    """Forward own value.
+
+    The same as :class:`Field`, except that `src` is always this field
+    itself.
+
+    .. py:attribute:: dst
+
+    The name of the key of the forwarded value from the src field in the
+    forwarded dictionary. If this value is ``None``, then the key is
+    ``self``.
+    """
+    type = "self"
+
+    def __init__(self, dst=None):
+        """Instantiate a forwarded field value."""
+        self.dst = dst
+
+    def to_dict(self):
+        """Convert to dictionary which will be rendered as JSON."""
+        d = super(Self, self).to_dict()
+
+        if self.dst is not None:
+            d.update(dst=self.dst)
+
+        return d

--- a/src/dal/static/autocomplete_light/forward.js
+++ b/src/dal/static/autocomplete_light/forward.js
@@ -1,0 +1,183 @@
+;(function($, yl) {
+    yl.forwardHandlerRegistry = yl.forwardHandlerRegistry || {};
+
+    yl.registerForwardHandler = function(name, handler) {
+        yl.forwardHandlerRegistry[name] = handler;
+    };
+
+    yl.getForwardHandler = function(name) {
+        return yl.forwardHandlerRegistry[name];
+    };
+
+    function getForwardStrategy(element) {
+        var checkForCheckboxes = function() {
+            var all = true;
+            $.each(element, function(ix, e) {
+                if ($(e).attr("type") !== "checkbox") {
+                    all = false;
+                }
+            });
+            return all;
+        };
+
+        if (element.length === 1 &&
+                element.attr("type") === "checkbox" &&
+                element.attr("value") === undefined) {
+            // Single checkbox without 'value' attribute
+            // Boolean field
+            return "exists";
+        } else if (element.length === 1 &&
+                element.attr("multiple") !== undefined) {
+            // Multiple by HTML semantics. E. g. multiple select
+            // Multiple choice field
+            return "multiple";
+        } else if (checkForCheckboxes()) {
+            // Multiple checkboxes or one checkbox with 'value' attribute.
+            // Multiple choice field represented by checkboxes
+            return "multiple";
+        } else {
+            // Other cases
+            return "single";
+        }
+    }
+
+    /**
+     * Get fields with name `name` relative to `element` with considering form
+     * prefixes.
+     * @param element the element
+     * @param name name of the field
+     * @returns jQuery object with found fields or empty jQuery object if no
+     * field was found
+     */
+    yl.getFieldRelativeTo = function(element, name) {
+        var prefixes = $(element).getFormPrefixes();
+
+        for (var i = 0; i < prefixes.length; i++) {
+            var fieldSelector = "[name=" + prefixes[i] + name + "]";
+            var field = $(fieldSelector);
+
+            if (field.length) {
+                return field;
+            }
+        }
+
+        return $();
+    };
+
+    /**
+     * Get field value which is put to forwarded dictionary
+     * @param field the field
+     * @returns forwarded value
+     */
+    yl.getValueFromField = function(field) {
+        var strategy = getForwardStrategy(field);
+        var serializedField = $(field).serializeArray();
+
+        var getSerializedFieldElementAt = function (index) {
+            // Return serializedField[index]
+            // or null if something went wrong
+            if (serializedField.length > index) {
+                return serializedField[index];
+            } else {
+                return null;
+            }
+        };
+
+        var getValueOf = function (elem) {
+            // Return elem.value
+            // or null if something went wrong
+            if (elem.hasOwnProperty("value") &&
+                elem.value !== undefined
+            ) {
+                return elem.value;
+            } else {
+                return null;
+            }
+        };
+
+        var getSerializedFieldValueAt = function (index) {
+            // Return serializedField[index].value
+            // or null if something went wrong
+            var elem = getSerializedFieldElementAt(index);
+            if (elem !== null) {
+                return getValueOf(elem);
+            } else {
+                return null;
+            }
+        };
+
+        if (strategy === "multiple") {
+            return serializedField.map(
+                function (item) {
+                    return getValueOf(item);
+                }
+            );
+        } else if (strategy === "exists") {
+            return serializedField.length > 0;
+        } else {
+            return getSerializedFieldValueAt(0);
+        }
+    };
+
+    yl.getForwards = function(element) {
+        var forwardElem,
+            forwardList,
+            forwardedData,
+            divSelector,
+            form;
+        divSelector = "div.dal-forward-conf#dal-forward-conf-for-" +
+                element.attr("id");
+        form = element.length > 0 ? $(element[0].form) : $();
+
+        forwardElem =
+            form.find(divSelector).find('script');
+        if (forwardElem.length === 0) {
+            return;
+        }
+        try {
+            forwardList = JSON.parse(forwardElem.text());
+        } catch (e) {
+            return;
+        }
+
+        if (!Array.isArray(forwardList)) {
+            return;
+        }
+
+        forwardedData = {};
+
+        $.each(forwardList, function(ix, field) {
+            var srcName, dstName;
+            if (field.type === "const") {
+                forwardedData[field.dst] = field.val;
+            } else if (field.type === "self") {
+                if (field.hasOwnProperty("dst")) {
+                    dstName = field.dst;
+                } else {
+                    dstName = "self";
+                }
+                forwardedData[dstName] = yl.getValueFromField(element);
+            } else if (field.type === "field") {
+                srcName = field.src;
+                if (field.hasOwnProperty("dst")) {
+                    dstName = field.dst;
+                } else {
+                    dstName = srcName;
+                }
+                var forwardedField = yl.getFieldRelativeTo(element, srcName);
+
+                if (!forwardedField.length) {
+                    return;
+                }
+
+                forwardedData[dstName] = yl.getValueFromField(forwardedField);
+            } else if (field.type === "javascript") {
+                var handler = yl.getForwardHandler(field.handler);
+                forwardedData[field.dst || field.handler] = handler(element);
+            }
+
+        });
+        return JSON.stringify(forwardedData);
+    };
+
+})(yl.jQuery, yl);

--- a/src/dal_select2/static/autocomplete_light/select2.js
+++ b/src/dal_select2/static/autocomplete_light/select2.js
@@ -1,139 +1,4 @@
 ;(function ($) {
-    function getForwardStrategy(element) {
-        var checkForCheckboxes = function() {
-            var all = true;
-            $.each(element, function(ix, e) {
-                if ($(e).attr("type") !== "checkbox") {
-                    all = false;
-                }
-            });
-            return all;
-        };
-
-        if (element.length === 1 &&
-                element.attr("type") === "checkbox" &&
-                element.attr("value") === undefined) {
-            // Single checkbox without 'value' attribute
-            // Boolean field
-            return "exists";
-        } else if (element.length === 1 &&
-                element.attr("multiple") !== undefined) {
-            // Multiple by HTML semantics. E. g. multiple select
-            // Multiple choice field
-            return "multiple";
-        } else if (checkForCheckboxes()) {
-            // Multiple checkboxes or one checkbox with 'value' attribute.
-            // Multiple choice field represented by checkboxes
-            return "multiple";
-        } else {
-            // Other cases
-            return "single";
-        }
-    }
-
-    function getForwards(element) {
-        var forwardElem,
-            forwardList,
-            prefix,
-            forwardedData,
-            divSelector,
-            form;
-        divSelector = "div.dal-forward-conf#dal-forward-conf-for-" +
-                element.attr("id");
-        form = element.length > 0 ? $(element[0].form) : $();
-
-        forwardElem =
-            form.find(divSelector).find('script');
-        if (forwardElem.length === 0) {
-            return;
-        }
-        try {
-            forwardList = JSON.parse(forwardElem.text());
-        } catch (e) {
-            return;
-        }
-
-        if (!Array.isArray(forwardList)) {
-            return;
-        }
-
-        prefixes = $(element).getFormPrefixes();
-        forwardedData = {};
-
-        $.each(forwardList, function(ix, f) {
-            if (f.type === "const") {
-                forwardedData[f.dst] = f.val;
-            } else if (f.type === "field") {
-                var srcName,
-                    dstName;
-                srcName = f.src;
-                if (f.hasOwnProperty("dst")) {
-                    dstName = f.dst;
-                } else {
-                    dstName = srcName;
-                }
-                for (var i = 0; i < prefixes.length; i++) {
-                    var fieldSelector = '[name=' + prefixes[i] + srcName + ']';
-                    var field = $(fieldSelector);
-
-                    if (!field.length) {
-                        continue;
-                    }
-
-                    var strategy = getForwardStrategy(field);
-                    var serializedField = field.serializeArray();
-
-                    var getSerializedFieldElementAt = function (index) {
-                        // Return serializedField[index]
-                        // or null if something went wrong
-                        if (serializedField.length > index) {
-                            return serializedField[index];
-                        } else {
-                            return null;
-                        }
-                    };
-
-                    var getValueOf = function (elem) {
-                        // Return elem.value
-                        // or null if something went wrong
-                        if (elem.hasOwnProperty("value") &&
-                            elem.value !== undefined
-                        ) {
-                            return elem.value;
-                        } else {
-                            return null;
-                        }
-                    };
-
-                    var getSerializedFieldValueAt = function (index) {
-                        // Return serializedField[index].value
-                        // or null if something went wrong
-                        var elem = getSerializedFieldElementAt(index);
-                        if (elem !== null) {
-                            return getValueOf(elem);
-                        } else {
-                            return null;
-                        }
-                    };
-
-                    if (strategy === "multiple") {
-                        forwardedData[dstName] = serializedField.map(
-                            function (item) {
-                                return getValueOf(item);
-                            }
-                        );
-                    } else if (strategy === "exists") {
-                        forwardedData[dstName] = serializedField.length > 0;
-                    } else {
-                        forwardedData[dstName] = getSerializedFieldValueAt(0);
-                    }
-                    break;
-                }
-            }
-        });
-        return JSON.stringify(forwardedData);
-    }
-
     $(document).on('autocompleteLightInitialize', '[data-autocomplete-light-function=select2]', function() {
         var element = $(this);
 
@@ -177,7 +42,7 @@
                         q: params.term, // search term
                         page: params.page,
                         create: element.attr('data-autocomplete-light-create') && !element.attr('data-tags'),
-                        forward: getForwards(element)
+                        forward: yl.getForwards(element)
                     };
 
                     return data;
@@ -224,7 +89,7 @@
                 dataType: 'json',
                 data: {
                     text: data.id,
-                    forward: getForwards($(this))
+                    forward: yl.getForwards($(this))
                 },
                 beforeSend: function(xhr, settings) {
                     xhr.setRequestHeader("X-CSRFToken", document.csrftoken);

--- a/src/dal_select2/widgets.py
+++ b/src/dal_select2/widgets.py
@@ -52,6 +52,7 @@ class Select2WidgetMixin(object):
               'autocomplete_light/vendor/select2/dist/js/select2.full.{}js'.format(  # noqa
                   _min),
               ) + i18n_file + (
+            'autocomplete_light/forward.js',
             'autocomplete_light/select2.js',
         )
 

--- a/test_project/forward_different_fields/forms.py
+++ b/test_project/forward_different_fields/forms.py
@@ -38,7 +38,14 @@ class TForm(forms.ModelForm):
                      "select_radio",
                      "multiselect",
                      "multiselect_checks",
-                     forward.Field(src="multiselect_checks_poor"))
+                     forward.Field(src="multiselect_checks_poor"),
+                     forward.JavaScript(handler="const42",
+                                        dst="const42"),
+                     forward.JavaScript(
+                         handler="reverse_name",
+                         dst="reverse_name"),
+                     forward.Self()
+                     )
 
         )
     )
@@ -53,3 +60,8 @@ class TForm(forms.ModelForm):
                   'multiselect_checks',
                   'multiselect_checks_poor',
                   'test')
+
+    class Media:
+        js = (
+            'js_handlers.js',
+        )

--- a/test_project/forward_different_fields/static/js_handlers.js
+++ b/test_project/forward_different_fields/static/js_handlers.js
@@ -1,0 +1,12 @@
+$(document).ready(function() {
+    yl.registerForwardHandler("const42", function () {
+        return 42;
+    });
+
+    yl.registerForwardHandler("reverse_name", function(elem) {
+        var field = yl.getFieldRelativeTo(elem, "name");
+
+        var name = field.val();
+        return name.split("").reverse().join("");
+    });
+});

--- a/test_project/forward_different_fields/urls.py
+++ b/test_project/forward_different_fields/urls.py
@@ -5,7 +5,6 @@ from django.conf.urls import url
 
 class ListWithForwardsView(autocomplete.Select2ListView):
     def get_list(self):
-
         name = self.forwarded.get("name")
         checkbox = self.forwarded.get("checkbox")
         select = self.forwarded.get("select")
@@ -13,17 +12,10 @@ class ListWithForwardsView(autocomplete.Select2ListView):
         multiselect = self.forwarded.get("multiselect")
         multiselect_checks = self.forwarded.get("multiselect_checks")
         multiselect_checks_poor = self.forwarded.get("multiselect_checks_poor")
+        const42 = self.forwarded.get("const42")
+        reversed_name = self.forwarded.get("reverse_name")
 
-        if name == "Helen" and \
-                checkbox is True and \
-                select == "c" and \
-                select_radio == "b" and \
-                multiselect == ["b", "c"] and \
-                multiselect_checks == ["a", "c"] and \
-                multiselect_checks_poor == ["d"]:
-            return ["It works!"]
-        else:
-            return ["Check another combination!"]
+        return [str(self.forwarded)]
 
 
 urlpatterns = [


### PR DESCRIPTION
This work is based on #843 and adds two more forward features.

Currently there are no tests and docs and the purpose of this PR currently is to illustrate my comment in #894 .

The idea is following:

On server side user defines `Js("someCallback")` as a forwarded value. After that somewhere is JS he should register this callback to DAL:
```js
yl.registerForwardHandler("reverse_name", function(elem, prefix) {
     // Do stuff and return forwarded value
     return 42;
});
```

One thing to be considered is to expose some DAL machinery used for searching fields and extracting values as DAL JS API (like `getFieldRelativeTo` and `getValueFromField`).


Another feature implemented here is forwarding values from DAL widget itself (`Self()`).