### PR TITLE
Fix KeyError when id is not in attrs

### DIFF
--- a/src/dal/widgets.py
+++ b/src/dal/widgets.py
@@ -148,7 +148,7 @@ class WidgetMixin(object):
     def render(self, name, value, attrs=None):
         """Calling Django render together with `render_forward_conf`."""
         widget = super(WidgetMixin, self).render(name, value, attrs)
-        conf = self.render_forward_conf(attrs['id'])
+        conf = self.render_forward_conf(attrs['id']) if 'id' in attrs else ""
         return mark_safe(widget + conf)
 
     def _get_url(self):


### PR DESCRIPTION
Ran into this issue when adding a User autocomplete to an admin ActionForm. My other autocompletes work fine and this one change allowed this one to work as well. Unsure why this works but perhaps because my form is not a ModelForm?