### PR TITLE
Django 1.11 for V2: update build_attrs

### DIFF
--- a/autocomplete_light/widgets.py
+++ b/autocomplete_light/widgets.py
@@ -160,7 +160,7 @@ class WidgetBase(object):
 
         autocomplete = self.autocomplete(values=value)
 
-        attrs = self.build_attrs(attrs, autocomplete=autocomplete)
+        attrs = self.build_attrs(self.attrs, attrs, autocomplete=autocomplete)
 
         self.html_id = attrs.pop('id', name)
 
@@ -182,9 +182,9 @@ class WidgetBase(object):
                 self.widget_template)
         return safestring.mark_safe(render_to_string(template, context))
 
-    def build_attrs(self, extra_attrs=None, autocomplete=None, **kwargs):
-        self.attrs.update(getattr(autocomplete, 'attrs', {}))
-        attrs = super(WidgetBase, self).build_attrs(extra_attrs, **kwargs)
+    def build_attrs(self, attrs, extra_attrs=None, autocomplete=None, **kwargs):
+        attrs.update(getattr(autocomplete, 'attrs', {}))
+        attrs = super(WidgetBase, self).build_attrs(attrs, extra_attrs, **kwargs)
 
         if 'class' not in attrs.keys():
             attrs['class'] = ''
@@ -302,14 +302,14 @@ class TextWidget(WidgetBase, forms.TextInput):
         """ Proxy Django's TextInput.render() """
 
         autocomplete = self.autocomplete(values=value)
-        attrs = self.build_attrs(attrs, autocomplete=autocomplete)
+        attrs = self.build_attrs(self.attrs, attrs, autocomplete=autocomplete)
 
         return forms.TextInput.render(self, name, value, attrs)
 
-    def build_attrs(self, extra_attrs=None, autocomplete=None, **kwargs):
-        attrs = super(TextWidget, self).build_widget_attrs()
+    def build_attrs(self, attrs, extra_attrs=None, autocomplete=None, **kwargs):
+        attrs.update(super(TextWidget, self).build_widget_attrs())
         attrs.update(super(TextWidget, self).build_attrs(
-            extra_attrs, **kwargs))
+            self.attrs, extra_attrs, **kwargs))
         attrs.update(getattr(autocomplete, 'attrs', {}))
 
         def update_attrs(source, prefix=''):

--- a/autocomplete_light/widgets.py
+++ b/autocomplete_light/widgets.py
@@ -182,10 +182,12 @@ class WidgetBase(object):
                 self.widget_template)
         return safestring.mark_safe(render_to_string(template, context))
 
-    def build_attrs(self, attrs, extra_attrs=None, autocomplete=None, **kwargs):
+    def build_attrs(self, attrs, extra_attrs=None,
+                    autocomplete=None, **kwargs):
         attrs.copy()
         attrs.update(getattr(autocomplete, 'attrs', {}))
-        attrs = super(WidgetBase, self).build_attrs(attrs, extra_attrs, **kwargs)
+        attrs = super(WidgetBase, self).build_attrs(
+            attrs, extra_attrs, **kwargs)
 
         if 'class' not in attrs.keys():
             attrs['class'] = ''
@@ -307,7 +309,8 @@ class TextWidget(WidgetBase, forms.TextInput):
 
         return forms.TextInput.render(self, name, value, attrs)
 
-    def build_attrs(self, attrs, extra_attrs=None, autocomplete=None, **kwargs):
+    def build_attrs(self, attrs, extra_attrs=None,
+                    autocomplete=None, **kwargs):
         attrs.copy()
         attrs.update(super(TextWidget, self).build_widget_attrs())
         attrs.update(getattr(autocomplete, 'attrs', {}))

--- a/autocomplete_light/widgets.py
+++ b/autocomplete_light/widgets.py
@@ -183,6 +183,7 @@ class WidgetBase(object):
         return safestring.mark_safe(render_to_string(template, context))
 
     def build_attrs(self, attrs, extra_attrs=None, autocomplete=None, **kwargs):
+        attrs.copy()
         attrs.update(getattr(autocomplete, 'attrs', {}))
         attrs = super(WidgetBase, self).build_attrs(attrs, extra_attrs, **kwargs)
 
@@ -307,10 +308,11 @@ class TextWidget(WidgetBase, forms.TextInput):
         return forms.TextInput.render(self, name, value, attrs)
 
     def build_attrs(self, attrs, extra_attrs=None, autocomplete=None, **kwargs):
+        attrs.copy()
         attrs.update(super(TextWidget, self).build_widget_attrs())
+        attrs.update(getattr(autocomplete, 'attrs', {}))
         attrs.update(super(TextWidget, self).build_attrs(
             self.attrs, extra_attrs, **kwargs))
-        attrs.update(getattr(autocomplete, 'attrs', {}))
 
         def update_attrs(source, prefix=''):
             for key, value in source.items():


### PR DESCRIPTION
Updates for version 2 for Django 1.11

The signature for build_attrs was changed for Django 1.11 widgets