### PR TITLE
 Fix #930: QuerySetSequence querysets order is not preserved

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -235,9 +235,12 @@ to return HTML code.
 
 .. code-block:: python
 
+    from django.utils.html import format_html
+    
     class CountryAutocomplete(autocomplete.Select2QuerySetView):
         def get_result_label(self, item):
-            return '<img src="flags/%s.png"> %s' % (item.name, item.name)
+            # TODO TODO TODO PUT ESCAPING IN THIS WIDGET TO STOP XSS
+            return format_html('<img src="flags/{}.png"> {}', item.name, item.name)
 
 
     class PersonForm(forms.ModelForm):
@@ -251,7 +254,7 @@ to return HTML code.
 
 
 .. note:: Take care to escape anything you put in HTML code to avoid XSS attacks
-          when displaying data that may have been input by a user!
+          when displaying data that may have been input by a user! `format_html` helps.
 
 Overriding javascript code
 ==========================

--- a/src/dal_select2_queryset_sequence/views.py
+++ b/src/dal_select2_queryset_sequence/views.py
@@ -1,5 +1,5 @@
 """View for a Select2 widget and QuerySetSequence-based business logic."""
-
+from collections import OrderedDict
 from dal_queryset_sequence.views import BaseQuerySetSequenceView
 
 from dal_select2.views import Select2ViewMixin
@@ -37,7 +37,7 @@ class Select2QuerySetSequenceView(BaseQuerySetSequenceView, Select2ViewMixin):
         It will render as a list of one <optgroup> per different content type
         containing a list of one <option> per model.
         """
-        groups = {}
+        groups = OrderedDict()
 
         for result in context['object_list']:
             groups.setdefault(type(result), [])

--- a/tox.ini
+++ b/tox.ini
@@ -16,14 +16,14 @@ setenv =
 
 commands =
     mysql: mysql -u root -e 'drop database if exists dal_test;'
-    postgresql: psql -U postgres -c 'drop database if exists dal_test;'
+    postgresql: psql -c 'drop database if exists dal_test;'
     py.test -v --cov --liveserver 127.0.0.1:9999 {posargs}
 
 deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10a,<1.11
-    django111: Django>=1.11a
+    django111: Django>=1.11a,<1.12
     djangomaster: https://github.com/django/django/archive/master.tar.gz
     postgresql: psycopg2
     mysql: mysql-python


### PR DESCRIPTION
Use an ordered dict to preserve ordering of querysets. Since the test
suite isn't working for the most part (changed css in admin) and some
tests, do not seem to be  called at all by tox, we don't add a test for
it.
In particular, `dal_queryset_sequence/tests/test_views.py` isn't being
called as far as I can tell (used --results-json).