### PR TITLE
Update tutorial.rst to fix XSS in the example

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -235,9 +235,12 @@ to return HTML code.
 
 .. code-block:: python
 
+    from django.utils.html import format_html
+    
     class CountryAutocomplete(autocomplete.Select2QuerySetView):
         def get_result_label(self, item):
-            return '<img src="flags/%s.png"> %s' % (item.name, item.name)
+            # TODO TODO TODO PUT ESCAPING IN THIS WIDGET TO STOP XSS
+            return format_html('<img src="flags/{}.png"> {}', item.name, item.name)
 
 
     class PersonForm(forms.ModelForm):
@@ -251,7 +254,7 @@ to return HTML code.
 
 
 .. note:: Take care to escape anything you put in HTML code to avoid XSS attacks
-          when displaying data that may have been input by a user!
+          when displaying data that may have been input by a user! `format_html` helps.
 
 Overriding javascript code
 ==========================


### PR DESCRIPTION
Hello,

I appreciate the existing warning about XSS, but since many will just copy and paste the example given here, I think it is crucial to make the example safe from XSS. Simply using `format_html` does the trick.

(Note: I have noticed that folks sometimes think `%` operator could be overloaded to do escaping automagically - so they might not even realize that what they are copy-pasting is not safe yet.)

Thanks for your consideration on this matter!

Best
Michael