### PR TITLE
Use proper selector in DOMElementInserted

### DIFF
--- a/src/dal/static/autocomplete_light/autocomplete.init.js
+++ b/src/dal/static/autocomplete_light/autocomplete.init.js
@@ -89,7 +89,7 @@ element was cloned with data - which should be the case.
     });
 
     $(document).bind('DOMNodeInserted', function(e) {
-        $(e.target).find('[data-autocomplete-light-function=select2]').each(initialize);
+        $(e.target).find('[data-autocomplete-light-function=select2]:not([id*="__prefix__"])').each(initialize);
     });
 
     // using jQuery


### PR DESCRIPTION
This PR proposes to use the same selector in `DOMNodeInserted` callback as we use in `document.ready` callback.

The old version works well in most cases: we avoid select2 init on template form (that matches `[id*="__prefix__"]`) only in `document.ready`. The most calls to `DOMNodeInserted` are performed when user clicks "Add": the template form is cloned and inserted as new node, so we don't have to avoid `[id*="__prefix__"]` here. 

However, in some rare cases the template form itself is not present on page load and added to the page later (by AJAX for example). In that case Select2 is initialized twice: first for template form and then again when it is copied. This patch fixes this case.

It does not break anything on latest Django in admin, however I am not sure about older Django versions and outside-of-admin implementations of inlines (such as [this one](https://github.com/elo80ka/django-dynamic-formset))