### PR TITLE
Use http.JsonResponse when the response is JSON

### DIFF
--- a/src/dal_select2/views.py
+++ b/src/dal_select2/views.py
@@ -55,15 +55,13 @@ class Select2ViewMixin(object):
 
         create_option = self.get_create_option(context, q)
 
-        return http.HttpResponse(
-            json.dumps({
+        return http.JsonResponse(
+            {
                 'results': self.get_results(context) + create_option,
                 'pagination': {
                     'more': self.has_more(context)
                 }
-            }),
-            content_type='application/json',
-        )
+            })
 
 
 class Select2QuerySetView(Select2ViewMixin, BaseQuerySetView):
@@ -89,9 +87,9 @@ class Select2ListView(ViewMixin, View):
                     'text': 'Create "%s"' % self.q,
                     'create_id': True
                 }]
-        return http.HttpResponse(json.dumps({
+        return http.JsonResponse({
             'results': self.results(results) + create_option
-        }), content_type='application/json')
+        }, content_type='application/json')
 
     def autocomplete_results(self, results):
         """Return list of strings that match the autocomplete query."""
@@ -120,10 +118,10 @@ class Select2ListView(ViewMixin, View):
         if text is None:
             return http.HttpResponseBadRequest()
 
-        return http.HttpResponse(json.dumps({
+        return http.JsonResponse({
             'id': text,
             'text': text,
-        }))
+        })
 
 
 class Select2GroupListView(Select2ListView):
@@ -167,10 +165,10 @@ class Select2GroupListView(Select2ListView):
                 results_dict.setdefault(group, [])
                 results_dict[group].append(value)
 
-        return http.HttpResponse(json.dumps({
+        return http.JsonResponse({
             "results":
                 [{"id": x, "text": x} for x in results_dict.pop(None, [])] +
                 [{"id": g, "text": g, "children": [{"id": x, "text": x}
                                                    for x in l]}
                  for g, l in six.iteritems(results_dict)]
-        }))
+        })


### PR DESCRIPTION
**Warning** this is untested. I have splinter errors when running tox.

http.HttpResponse with manual json.dumps call is, well, kind of acceptable. Unless you forget to set content_type to „application/json”. But then, everything still is fine, tests pass and stuff. But then, after some time, you run the code in the production, on, say, nginx+uwsgi. This combo will attach HTML tags to your json responses, head, body, the html tag itself, thus rendering json responses as unreadable to the client.

TL;DR: Use http.JsonResponse when the response is JSON