### PR TITLE
Fix #981, „create” option wrong behavior

### DIFF
--- a/src/dal/static/autocomplete_light/autocomplete.init.js
+++ b/src/dal/static/autocomplete_light/autocomplete.init.js
@@ -82,15 +82,18 @@ element was cloned with data - which should be the case.
         $(element).trigger('autocompleteLightInitialize');
         initialized.push(element);
     }
-    window.__dal__initialize = initialize;
 
-    $(document).ready(function() {
-        $('[data-autocomplete-light-function=select2]:not([id*="__prefix__"])').each(initialize);
-    });
+    if (!window.__dal__initialize) {
+        window.__dal__initialize = initialize;
 
-    $(document).bind('DOMNodeInserted', function(e) {
-        $(e.target).find('[data-autocomplete-light-function=select2]:not([id*="__prefix__"])').each(initialize);
-    });
+        $(document).ready(function () {
+            $('[data-autocomplete-light-function=select2]:not([id*="__prefix__"])').each(initialize);
+        });
+
+        $(document).bind('DOMNodeInserted', function (e) {
+            $(e.target).find('[data-autocomplete-light-function=select2]:not([id*="__prefix__"])').each(initialize);
+        });
+    }
 
     // using jQuery
     function getCookie(name) {

--- a/src/dal_select2/static/autocomplete_light/select2.js
+++ b/src/dal_select2/static/autocomplete_light/select2.js
@@ -1,4 +1,7 @@
 ;(function ($) {
+    if (window.__dal__initListenerIsSet)
+        return;
+
     $(document).on('autocompleteLightInitialize', '[data-autocomplete-light-function=select2]', function() {
         var element = $(this);
 


### PR DESCRIPTION
There is a bug in „Create” option behavior, when some javascript files are included multiple times.

The premise of this bug is: I have no control over what my django.admin includes in the HTML source. I do have a global search form, based on autocomplete, so I need to include dal JavaScript on every single page. And, occasionally, I do have a form with autocomplete. Django admin adds form.media, so I may get dal's JavaScript included many times.

If I include autocomplete.init.js and/or select2.js more than once, I do get a strange, erroneous behaviour but when? Only when I use that small, very useful "Create '%s'" option.

The item created gets submitted more than once. It gets submitted so many times as the times the autocomplete.init.js and select2.js is included. So, usually the first request that hits the server gets OK'd (HTTP status 200), another requests fail with 500 Server Error and I get stack trace about non-unique primary keys in my tables, because the software tries to create the item many times.

This pull requests fixes #981 