### PR TITLE
Generic Foreign Key content type field autcompletion

### DIFF
--- a/src/dal/forms.py
+++ b/src/dal/forms.py
@@ -163,8 +163,8 @@ class FutureModelForm(forms.ModelForm):
         return self.instance
 
       
-  class GenericForeignKeyModelFormMeta(type): 
-    
+class GenericForeignKeyModelFormMeta(type): 
+
     def __new__(mcs, name, bases, dct):
 
         class GenericForeignKeyModelForm(autocomplete.FutureModelForm):

--- a/src/dal/forms.py
+++ b/src/dal/forms.py
@@ -53,6 +53,7 @@ from django import forms
 
 from dal_queryset_sequence.fields import GenericForeignKeyModelField
 from dal_select2_queryset_sequence.widgets import QuerySetSequenceSelect2
+from queryset_sequence import QuerySetSequence
 
 
 class FutureModelForm(forms.ModelForm):
@@ -170,10 +171,10 @@ class GenericForeignKeyModelFormMeta(type):
         ct_field = content_object.ct_field  # content_type field name
         fk_field = content_object.fk_field  # object id field name
 
-        class GenericForeignKeyModelForm(autocomplete.FutureModelForm):
+        class GenericForeignKeyModelForm(FutureModelForm):
             content_type_models = dct['filter_queryset']  # models to be validated, needs to be there, readed from the view
             queryset_models = [model.objects.all() for model in content_type_models]
-            _queryset_seq = autocomplete.QuerySetSequence(*queryset_models)
+            _queryset_seq = QuerySetSequence(*queryset_models)
 
             # class attribute set from string
             locals()[fk_field] = GenericForeignKeyModelField(

--- a/src/dal_queryset_sequence/fields.py
+++ b/src/dal_queryset_sequence/fields.py
@@ -133,3 +133,11 @@ class QuerySetSequenceModelMultipleField(ContentTypeModelMultipleFieldMixin,
                 self.raise_invalid_choice(params={'value': val})
 
         return queryset
+    
+    
+class GenericForeignKeyModelField(QuerySetSequenceModelField):
+
+    def get_queryset_for_content_type(self, content_type_id):
+        """Export the content_type object as an attribute"""
+        self.content_type = ContentType.objects.get_for_id(content_type_id) 
+        return super().get_queryset_for_content_type(content_type_id)


### PR DESCRIPTION
And also lighter syntax for creating FutureModelForm for GFK

**Usage**:

`models.py`

```python
class MyModel(models.Model):
    name models.CharField(max_length=300)
    content_type_field = models.ForeignKey(ContentType, on_delete=models.CASCADE, null=True, blank=True,
                                    limit_choices_to=models.Q(model='Model1') | models.Q(model='Model2')  
                                    ) 
    object_id_field = models.CharField(max_length=300, null=True, blank=True)
    content_object = GenericForeignKey('content_type_field', 'object_id_field')

    def __str__(self):
        return self.name
```

`forms.py`

```python
class GFKMyModelForm(metaclass=GenericForeignKeyModelFormMeta):
    content_type_field_name = 'content_type_field'  # attribute name from models.py
    object_id_field_name = 'object_id_field'
    view_name = 'autocomp'  # the view url name
    filter_queryset = [Model1, Model2]

    class Meta:
        model = Treatment
        fields = '__all__'
```


`view.py`

```python
class AutocompView(Select2QuerySetSequenceView):

    def get_queryset(self):
        # get the models direclty for the form object
        queryset_models = [model.objects.all() for model in GFKMyModelForm.content_type_models]  
        if self.q: 
            queryset_models[0].filter(alias__icontains=self.q)
            queryset_models[1].filter(name__icontains=self.q)

        # Aggregate querysets
        qs = QuerySetSequence(*queryset_models)

        qs = self.mixup_querysets(qs)

        return qs
```

Im aware that the small gain in syntax simplicity is largely counterbalanced by the increase of complexity on the source code, which is just a set of of ~ hacks because that's the only way i found without deeper changes in the source code.

I didn't code it the good way, but i think the modelForm interface i made for GFK is easier to use than the previous one, and the autocompletion of the content_type field is an useful feature.

For now it only support one GFK(content_type + object_id), but it only need a loop to support multiple GFK from one form.
