### PR TITLE
Added support for automatically generated views for generic foreign key fields

### DIFF
--- a/src/dal/autocomplete.py
+++ b/src/dal/autocomplete.py
@@ -57,6 +57,7 @@ if _installed('dal_queryset_sequence'):
     from dal_queryset_sequence.fields import (
         QuerySetSequenceModelField,
         QuerySetSequenceModelMultipleField,
+        GenericForeignKeyModelField,
     )
     from dal_queryset_sequence.views import (
         BaseQuerySetSequenceView,

--- a/src/dal/forms.py
+++ b/src/dal/forms.py
@@ -158,3 +158,13 @@ class FutureModelForm(forms.ModelForm):
             # saving of m2m data.
             self.save_m2m = self._save_m2m
         return self.instance
+
+    @classmethod
+    def as_url(cls):
+        """
+        Create a list of url patterns, to be called in url.py:
+        urlpattern.append(*ModelForm.as_url())
+        Iterate over the fields to call the as_url() method from the GenericForeignKeyField
+        """
+        return [value.as_url(cls) for key, value in cls.__dict__['declared_fields'].items()
+                if hasattr(value.__class__, 'as_url')]  # checks if its the right object

--- a/test_project/select2_generic_foreign_key/forms.py
+++ b/test_project/select2_generic_foreign_key/forms.py
@@ -6,13 +6,9 @@ from .models import TModel
 
 
 class TForm(autocomplete.FutureModelForm):
-    test = autocomplete.QuerySetSequenceModelField(
-        queryset=autocomplete.QuerySetSequence(
-            Group.objects.all(),
-            TModel.objects.all(),
-        ),
+    test = autocomplete.GenericForeignKeyModelField(
+        model_choice=[(Group, 'name'), (TModel, 'name')],  # Model with values to filter
         required=False,
-        widget=autocomplete.QuerySetSequenceSelect2('select2_gfk'),
     )
 
     class Meta:

--- a/test_project/select2_generic_foreign_key/urls.py
+++ b/test_project/select2_generic_foreign_key/urls.py
@@ -10,16 +10,6 @@ from .models import TModel
 
 urlpatterns = [
     url(
-        '^select2-gfk/$',
-        autocomplete.Select2QuerySetSequenceView.as_view(
-            queryset=autocomplete.QuerySetSequence(
-                Group.objects.all(),
-                TModel.objects.all(),
-            )
-        ),
-        name='select2_gfk',
-    ),
-    url(
         'test/(?P<pk>\d+)/$',
         generic.UpdateView.as_view(
             model=TModel,
@@ -27,3 +17,4 @@ urlpatterns = [
         )
     ),
 ]
+urlpatterns.append(*TForm.as_url())


### PR DESCRIPTION
**Usage**: 
`forms.py`
```python
class TForm(autocomplete.FutureModelForm):
    test = autocomplete.GenericForeignKeyModelField(
        model_choice=[(Group, 'name'), (TModel, 'name')],  # Model with values to filter
        required=False,
    )

    class Meta:
        model = TModel
        fields = ('name',)
```
`url.py`
```python
urlpatterns.append(*TForm.as_url())
```

- The view to filter the result displayed by the select2 widget is now automatically created
- Support different fields to filter
- The generic foreign key field instanciation in the form needs less argument, it's more DRY

Tests in the admin page seems ok, it's runable as it. I still need to add more tests and doc, and check if there is no problem with model with multiple GFK, but should be ok.

Maybe classes will have to be moved to other package, i don't know what was the best place to put them.
