### PR TITLE
Set select2 container CSS class to :all:

### DIFF
--- a/src/dal_select2/static/autocomplete_light/select2.js
+++ b/src/dal_select2/static/autocomplete_light/select2.js
@@ -66,6 +66,7 @@
         $(this).select2({
             tokenSeparators: element.attr('data-tags') ? [','] : null,
             debug: true,
+            containerCssClass: ':all:',
             placeholder: element.attr('data-placeholder') || '',
             language: element.attr('data-autocomplete-light-language'),
             minimumInputLength: element.attr('data-minimum-input-length') || 0,


### PR DESCRIPTION
This PR sets `containerCssClass: ':all:'` option when initializing select2. In the generated element, this makes select2 use the same CSS classes as were set on original select element.

This fixes some select2 display bugs that are encountered with Bootstrap 4. Bootstrap requires the form elements to have `form-control` class, which is lost on a generated element without this fix. See example [here](https://github.com/select2/select2-bootstrap-theme/pull/72#issuecomment-381151068).