### PR TITLE
Add Django 2.1 to the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,11 @@ env:
   matrix:
   - TOXENV=checkqa
   - TOXENV=base-py35-django20-sqlite
+  - TOXENV=base-py35-django21-sqlite
 matrix:
   allow_failures:
   - env: TOXENV=base-py35-django20-sqlite
+  - env: TOXENV=base-py35-django21-sqlite
 install:
 - travis_retry pip install -U pip
 - travis_retry pip install tox

--- a/AUTHORS
+++ b/AUTHORS
@@ -21,6 +21,7 @@ documentation to the project.
 - Bernhard Vallant
 - Brad Buran
 - Brant.Y
+- Bruno Alla
 - Daniele Procida
 - Daniel Hahler @blueyed
 - David Aurelio

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 # Note that django doesn't support pypy3 for now
 # https://code.djangoproject.com/ticket/25849
-envlist = base-py{27,34,35,36,py,py3}-django{18,19,110,111,20,master}-{sqlite,mysql,postgresql}
+envlist = base-py{27,34,35,36,py,py3}-django{18,19,110,111,20,21,master}-{sqlite,mysql,postgresql}
 
 [testenv]
 changedir = {toxinidir}/test_project
@@ -17,7 +17,7 @@ setenv =
 commands =
     mysql: mysql -u root -e 'drop database if exists dal_test;'
     postgresql: psql -c 'drop database if exists dal_test;'
-    django{20,master}: py.test -v --cov --liveserver 127.0.0.1:9999 {posargs} secure_data rename_forward select2_foreign_key select2_generic_foreign_key select2_list select2_many_to_many select2_one_to_one select2_outside_admin select2_taggit custom_select2 select2_nestedadmin
+    django{20,21,master}: py.test -v --cov --liveserver 127.0.0.1:9999 {posargs} secure_data rename_forward select2_foreign_key select2_generic_foreign_key select2_list select2_many_to_many select2_one_to_one select2_outside_admin select2_taggit custom_select2 select2_nestedadmin
     django1{8,9,10,11}: py.test -v --cov --liveserver 127.0.0.1:9999 {posargs}
 
 deps =
@@ -25,7 +25,8 @@ deps =
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<1.12
-    django20: Django==2.0,<2.1
+    django20: Django>=2.0,<2.1
+    django21: Django>=2.1,<2.2
     djangomaster: https://github.com/django/django/archive/master.tar.gz
     postgresql: psycopg2
     mysql: mysql-python


### PR DESCRIPTION
Django 2.1 has been released last week, so adding it to the build matrix.

This should help reproduce bugs like #1026 which is a problem only on Django 2.1+