### PR TITLE
Added missing renderer parameter to render method for django 2.1

### DIFF
--- a/src/dal/widgets.py
+++ b/src/dal/widgets.py
@@ -145,7 +145,7 @@ class WidgetMixin(object):
         self.choices = all_choices
         return result
 
-    def render(self, name, value, attrs=None, **kwargs):
+    def render(self, name, value, attrs=None, renderer=None, **kwargs):
         """Call Django render together with `render_forward_conf`."""
         widget = super(WidgetMixin, self).render(name, value, attrs, **kwargs)
         try:


### PR DESCRIPTION
The renderer parameter is mandatory in django 2.1, and it solves the issue #1026.