### PR TITLE
Fix ImportError with SELECT2_TRANSLATIONS in Django 1.x

### DIFF
--- a/src/dal_select2/widgets.py
+++ b/src/dal_select2/widgets.py
@@ -9,7 +9,11 @@ from dal.widgets import (
 
 from django import forms
 from django.conf import settings
-from django.contrib.admin.widgets import SELECT2_TRANSLATIONS
+try:
+    # SELECT2_TRANSLATIONS is Django 2.x only
+    from django.contrib.admin.widgets import SELECT2_TRANSLATIONS
+except ImportError:
+    SELECT2_TRANSLATIONS = {}
 from django.utils import six
 from django.utils import translation
 


### PR DESCRIPTION
Django2 introduced the SELECT2_TRANSLATIONS dictionary, and this
was imported into the dal_select2.widgets module, causing an ImportError
when run against any version of Django < 2.

Fixes #1029