### PR TITLE
Fixed exception raised from Select2QuerySetView when paginate_by is set to None

### DIFF
--- a/src/dal/views.py
+++ b/src/dal/views.py
@@ -73,7 +73,7 @@ class BaseQuerySetView(ViewMixin, BaseListView):
 
     def has_more(self, context):
         """For widgets that have infinite-scroll feature."""
-        return context['page_obj'].has_next()
+        return context['page_obj'].has_next() if context['page_obj'] else False
 
     def get_result_value(self, result):
         """Return the value of a result."""


### PR DESCRIPTION
Setting the class attribute `paginate_by = None` on a `Select2QuerySetView` subclass causes `BaseQuerySetView.has_more()` to raise an exception because `context['page_obj']` is `None`. 

This PR fixes that problem by having `has_more()` check if `context['page_obj']` is `None` before calling `has_next()` on it.