### PR TITLE
Fixed a jQuery conflict bug in the widget code.

### DIFF
--- a/src/dal/static/admin/js/jquery.init.js
+++ b/src/dal/static/admin/js/jquery.init.js
@@ -1,8 +1,0 @@
-var django = django || {};
-django.jQuery = jQuery
-
-var yl = yl || {};
-yl.jQuery = django.jQuery
-
-// this file also prevents django.jQuery.noConflict
-// there's got to be a better way ...

--- a/src/dal/static/autocomplete_light/jquery.init.js
+++ b/src/dal/static/autocomplete_light/jquery.init.js
@@ -1,9 +1,20 @@
 var yl = yl || {};
+// Directly above this file, we included the jQuery provided by django. That
+// means it set itself to window.$ and window.jQuery, and stored away any
+// existing jQuery that may have been installed previously. Calling
+// jQuery.noConflict(true) will remove OUR copy of jQuery from the global
+// namespace and restore the original values of window.$ and window.jQuery.
+// This is necessary so that code which uses a version of jQuery that may
+// have been installed up-page gets the version it expects.
+yl.jQuery = jQuery.noConflict(true);
 
-if (yl.jQuery === undefined) {
-    /* If the user has included another copy of jQuery use that, even in the admin */
-    if (typeof $ !== 'undefined')
-        yl.jQuery = $;
-    else if ((typeof django !== 'undefined') && (typeof django.jQuery !== 'undefined'))
-        yl.jQuery = django.jQuery;
+// Here, we set up django.jQuery, instead of letting admin/js/jquery.init.js
+// do it. This is necessary because it ALSO calls jQuery.noConflict(true).
+// It we let it do that, it would break any code further down the page that
+// expects window.$ and window.jQuery to be defined.
+var django = django || {};
+if (typeof django.jQuery === 'undefined') {
+    // If django.jQuery is not yet defined, we need to define it so that
+    // admin/js/autocomplete.js (which we include with our widget) can run.
+    django.jQuery = yl.jQuery;
 }

--- a/src/dal_select2/widgets.py
+++ b/src/dal_select2/widgets.py
@@ -46,7 +46,6 @@ class Select2WidgetMixin(object):
                 'admin/js/vendor/jquery/jquery%s.js' % extra,
                 'admin/js/vendor/select2/select2.full%s.js' % extra,
             ) + i18n_file + (
-                'admin/js/jquery.init.js',
                 'autocomplete_light/jquery.init.js',
                 'autocomplete_light/autocomplete.init.js',
                 'admin/js/autocomplete.js',


### PR DESCRIPTION
The comments in the diff go into detail about what this is doing, but the gist of this PR is that DAL's method of including Django's copy of jQuery was interfering with other javascript that was expecting a newer version of jQuery to be installed. I removed the override of `admin/js/jquery.init.js`, since DAL's version was doing it wrong, and changed `autocomplete_list/js/jquery.init.js` to do it right. The widget code now adds the jQuery from Django and then immediately removes it from the global namespace, restoring whatever version of jQuery was installed above the DAL widget code.

I originally discovered this problem when using a DAL widget on a Wagtail Page form that also had a DateTimeField. `jQuery.dateTimePicker()` was becoming undefined as soon as I added a DAL widget, and that turned out to be because DAL was overriding the jQuery 3.2.1 provided by Wagtail with the jQuery 2.2.3 provided by Django.