### PR TITLE
Fix: Forward ignores read_only fields

### DIFF
--- a/src/dal/static/autocomplete_light/forward.js
+++ b/src/dal/static/autocomplete_light/forward.js
@@ -73,6 +73,12 @@
         var strategy = getForwardStrategy(field);
         var serializedField = $(field).serializeArray();
 
+        if ((serializedField == false) && ($(field).prop('disabled'))) {
+            $(field).prop('disabled', false);
+            serializedField = $(field).serializeArray();
+            $(field).prop('disabled', true);
+        }
+
         var getSerializedFieldElementAt = function (index) {
             // Return serializedField[index]
             // or null if something went wrong


### PR DESCRIPTION
Maybe its possible to fix it within the Django code, but the fix works and there's no need not to serialize disabled fields, since we won't insert these into a Database / update a entry