### PR TITLE
[WIP] Switch to public api for retriving QSS querysets

### DIFF
--- a/src/dal_queryset_sequence/fields.py
+++ b/src/dal_queryset_sequence/fields.py
@@ -19,7 +19,7 @@ class QuerySetSequenceFieldMixin(object):
         """Return the QuerySet from the QuerySetSequence for a ctype."""
         content_type = ContentType.objects.get_for_id(content_type_id)
 
-        for queryset in self.queryset.query._querysets:
+        for queryset in self.queryset.get_querysets():
             if queryset.model.__name__ == 'QuerySequenceModel':
                 # django-queryset-sequence 0.7 support dynamically created
                 # QuerySequenceModel which replaces the original model when it

--- a/src/dal_queryset_sequence/views.py
+++ b/src/dal_queryset_sequence/views.py
@@ -31,10 +31,11 @@ class BaseQuerySetSequenceView(BaseQuerySetView):
 
     def mixup_querysets(self, qs):
         """Return a queryset with different model types."""
-        if len(list(qs.query._querysets)):
-            limit = int(self.paginate_by / len(qs.query._querysets))
-            qs.query._querysets[0][:2]
-            qs = QuerySetSequence(*[q[:limit] for q in qs.query._querysets])
+        querysets = list(qs.get_querysets())
+        queryset_count = len(querysets)
+        if queryset_count:
+            limit = int(self.paginate_by / queryset_count)
+            qs = QuerySetSequence(*[q[:limit] for q in querysets])
         return qs
 
     def get_queryset(self):


### PR DESCRIPTION
Switches from using an unsupported private API (which changed and broke
from django-querysetseqence>0.7) to a newly added public api method
(`get_querysets`) which achieves the same thing.

Depends on https://github.com/percipient/django-querysetsequence/pull/53
Supersedes #1056
Fixes #1050