### PR TITLE
Fix not iterable tag value

### DIFF
--- a/src/dal_select2/widgets.py
+++ b/src/dal_select2/widgets.py
@@ -16,6 +16,7 @@ except ImportError:
     SELECT2_TRANSLATIONS = {}
 from django.utils import six
 from django.utils import translation
+from django.utils.itercompat import is_iterable
 
 
 class Select2WidgetMixin(object):
@@ -126,12 +127,10 @@ class TagSelect2(WidgetMixin,
             if not v:
                 continue
 
-            if isinstance(v, six.string_types):
-                for t in v.split(','):
-                    values.add(self.option_value(t))
-            else:
-                for t in v:
-                    values.add(self.option_value(t))
+            v = v.split(',') if isinstance(v, six.string_types) else v
+            v = [v] if not is_iterable(v) else v
+            for t in v:
+                values.add(self.option_value(t))
         return values
 
     def options(self, name, value, attrs=None):
@@ -145,6 +144,7 @@ class TagSelect2(WidgetMixin,
                 continue
 
             real_values = v.split(',') if hasattr(v, 'split') else v
+            real_values = [real_values] if not is_iterable(real_values) else real_values
             for rv in real_values:
                 yield self.option_value(rv)
 


### PR DESCRIPTION
Hi,
there's a bug on rendering widget data of integrated `django-taggit` module.
`TagSelect2` class expects nested iterables but gets only flat list.

Thanks for your comments!