### PR TITLE
Taggit Select 2 Bug

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -57,6 +57,7 @@ documentation to the project.
 - Michał Sałaban
 - Mike Covington
 - Mislav Cimpersak
+- Mohammad Moallemi
 - Mounir Messelmeni
 - Maxim @mpyatishev
 - Nguyễn Hồng Quân

--- a/src/dal_select2_taggit/widgets.py
+++ b/src/dal_select2_taggit/widgets.py
@@ -9,6 +9,40 @@ from django.utils import six
 class TaggitSelect2(TagSelect2):
     """Select2 tag widget for taggit's TagField."""
 
+    """
+    if we want to edit an instance and fill tags with already added tags it causes exceptio:
+    Tag Object Not Iterable
+    
+    so i overwrited format_value , options in TaggitSelect2 and now it's good to go
+    """
+    def format_value(self, value):
+        """Return the list of HTML option values for a form field value."""
+        if not isinstance(value, (tuple, list)):
+            value = [value]
+        values = set()
+        for v in value:
+            if not v:
+                continue
+            if isinstance(v, six.string_types):
+                for t in v.split(','):
+                    values.add(self.option_value(t))
+            else:
+                values.add(self.option_value(v))
+        return values
+
+    def options(self, name, value, attrs=None):
+        """Return only select options."""
+        # When the data hasn't validated, we get the raw input
+        if isinstance(value, six.text_type):
+            value = value.split(',')
+
+        for v in value:
+            if not v:
+                continue
+
+            real_values = v.split(',') if hasattr(v, 'split') else v
+            yield self.option_value(real_values)
+
     def build_attrs(self, *args, **kwargs):
         """Add data-tags=","."""
         attrs = super(TaggitSelect2, self).build_attrs(*args, **kwargs)

--- a/test_project/select2_taggit/forms.py
+++ b/test_project/select2_taggit/forms.py
@@ -12,3 +12,12 @@ class TForm(forms.ModelForm):
         widgets = {
             'test': autocomplete.TaggitSelect2('select2_taggit')
         }
+
+
+class EditTForm(forms.ModelForm):
+    class Meta:
+        model = TModel
+        fields = ('name', 'test')
+        widgets = {
+            'test': autocomplete.TaggitSelect2('select2_taggit')
+        }

--- a/test_project/select2_taggit/views.py
+++ b/test_project/select2_taggit/views.py
@@ -1,0 +1,26 @@
+from django.shortcuts import render, get_object_or_404
+from .models import TModel
+from .forms import EditTForm
+
+
+def edit_t_model(request, pk):
+
+    """
+
+    without functions added in TaggitSelect2 page will raise exception:
+    Tag Object Not Iterable
+
+    """
+
+    tobject = get_object_or_404(TModel, pk=pk)
+
+    if request.method == 'POST':
+        main_form = EditTForm(request.POST, instance=tobject)
+    else:
+        main_form = EditTForm(instance=tobject)
+
+    context = {
+        'tobject': tobject,
+        'main_form': main_form,
+    }
+    return render(request, 'edit_t_model.html', context)


### PR DESCRIPTION
if we want to edit an instance and fill tags with already added tags it causes exception:
Tag Object Not Iterable

![Screenshot from 2019-05-13 16-37-03](https://user-images.githubusercontent.com/30885096/57620244-73863000-759d-11e9-9c8c-257921dee2b0.png)

so i overwrited inherited function format_value() , options() in TaggitSelect2 and now it's good to go

now it shows tags already added to object
![Screenshot from 2019-05-13 16-37-33](https://user-images.githubusercontent.com/30885096/57620245-73863000-759d-11e9-8bc5-8800eccdd9d9.png)

Bug Fixed!
