### PR TITLE
Travisci fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,9 @@ install:
 - travis_retry pip install -U pip
 - travis_retry pip install tox
 - travis_retry pip freeze
+services:
+  - xvfb
 before_script:
-- "export DISPLAY=:99.0"
-- "sh -e /etc/init.d/xvfb start"
-- sleep 3 # give xvfb some time to start
 - if echo "$TOXENV" | grep mysql; then mysql -e 'create database autocomplete_light_test;';
   fi
 - if echo "$TOXENV" | grep postgresql; then psql -c 'create database autocomplete_light_test;'

--- a/tox.ini
+++ b/tox.ini
@@ -53,6 +53,7 @@ deps =
     flake8-import-order
     mccabe
     pep8-naming
+    pydocstyle<4
 
 [testenv:docs]
 changedir = {toxinidir}/docs

--- a/tox.ini
+++ b/tox.ini
@@ -64,3 +64,6 @@ commands =
     make html
 whitelist_externals =
     make
+
+[flake8]
+max-line-length = 88


### PR DESCRIPTION
- fixes xvfb errors, cause by change in travisci environment
- workaorund for flake-docstrings error in testqa
- workaorund/fix line length erros from testqa

Since the lines causing the flake8 errors had already been merged and released I did the easiest thing and made 88 the new limit (borrowing from black's defaults), but that is debatable :)