### PR TITLE
Highlight select field with error to match Django style

### DIFF
--- a/src/dal_select2/static/autocomplete_light/select2.css
+++ b/src/dal_select2/static/autocomplete_light/select2.css
@@ -7,3 +7,8 @@ ul li.select2-search {
     /* Cancel out django's style */
     list-style-type: none;
 }
+
+.errors .select2-selection {
+    /* Highlight select box with error */
+    border-color: #ba2121;
+}


### PR DESCRIPTION
Since the Django generated select box is hidden with select2, the red border style does not appear when there is an error. This fix adds that style the select2 box.