### PR TITLE
Initialize all items on DOMNodeInserted and don't exclude prefix

### DIFF
--- a/src/dal/static/autocomplete_light/autocomplete.init.js
+++ b/src/dal/static/autocomplete_light/autocomplete.init.js
@@ -91,7 +91,7 @@ element was cloned with data - which should be the case.
         });
 
         $(document).bind('DOMNodeInserted', function (e) {
-            $(e.target).find('[data-autocomplete-light-function=select2]:not([id*="__prefix__"])').each(initialize);
+            $(e.target).find('[data-autocomplete-light-function=select2]').each(initialize);
         });
     }
 


### PR DESCRIPTION
This minor JS change enables DAL to work with the `jquery.formset.js` plugin that is commonly used. This PR reverses a change made a few versions ago adding more specificity to the `initialize`.