### PR TITLE
Update autocomplete init

### DIFF
--- a/src/dal/static/autocomplete_light/autocomplete.init.js
+++ b/src/dal/static/autocomplete_light/autocomplete.init.js
@@ -90,7 +90,7 @@ element was cloned with data - which should be the case.
             $('[data-autocomplete-light-function=select2]:not([id*="__prefix__"])').each(initialize);
         });
 
-        if ("MutationObserver" in window) {
+        if ('MutationObserver' in window) {
             new MutationObserver(function(mutations) {
                 var mutationRecord;
                 var addedNode;

--- a/src/dal/static/autocomplete_light/autocomplete.init.js
+++ b/src/dal/static/autocomplete_light/autocomplete.init.js
@@ -90,9 +90,29 @@ element was cloned with data - which should be the case.
             $('[data-autocomplete-light-function=select2]:not([id*="__prefix__"])').each(initialize);
         });
 
-        $(document).bind('DOMNodeInserted', function (e) {
-            $(e.target).find('[data-autocomplete-light-function=select2]').each(initialize);
-        });
+        if ("MutationObserver" in window) {
+            new MutationObserver(function(mutations) {
+                var mutationRecord;
+                var addedNode;
+
+                for (var i = 0; i < mutations.length; i++) {
+                    mutationRecord = mutations[i];
+
+                    if (mutationRecord.addedNodes.length > 0) {
+                        for (var j = 0; j < mutationRecord.addedNodes.length; j++) {
+                            addedNode = mutationRecord.addedNodes[j];
+
+                            $(addedNode).find('[data-autocomplete-light-function=select2]').each(initialize);
+                        }
+                    }
+                }
+
+            }).observe(document.documentElement, { childList: true, subtree: true });
+        } else {
+            $(document).on('DOMNodeInserted', function (e) {
+                $(e.target).find('[data-autocomplete-light-function=select2]').each(initialize);
+            });
+        }
     }
 
     // using jQuery


### PR DESCRIPTION
Hello, I noticed issues (#851 and #910 ) were opened related to `autocomplete.init.js` using `$(document).bind('DOMNodeInserted')` quite a while ago. However, it looks like the code related to these issues is [still there](https://github.com/yourlabs/django-autocomplete-light/blob/master/src/dal/static/autocomplete_light/autocomplete.init.js#L93). I decided to take a crack at a patch to address those issues with this proposed update to the `autocomplete.init` script. 

This uses a `MutationObserver` to watch for new widgets to initialize and falls back to `DOMNodeInserted` if `MutationObserver` is not available.