### PR TITLE
remove calculated widths

### DIFF
--- a/src/dal_select2/static/autocomplete_light/select2.js
+++ b/src/dal_select2/static/autocomplete_light/select2.js
@@ -80,6 +80,7 @@
             templateResult: result_template,
             templateSelection: selected_template,
             ajax: ajax,
+            with: null,
             tags: Boolean(element.attr('data-tags')),
         });
 


### PR DESCRIPTION
select2 erroneously calculates the width of the elements. It has been a knows issues for a while: https://github.com/select2/select2/issues/208 It's not resolved, but there is a workaround:

```js
$(element).select2({
  ...
  width: null
  ...
});
```

If there is a need to readjust the width It should be done vis CSS or dynamically after completion of rendering.

This is how the UI looks with ModelSelect2 before:

![screen_before000](https://user-images.githubusercontent.com/177266/82331264-fd31ce80-9a37-11ea-9fb8-98a2bbc18b22.png)

After:

![screen_after](https://user-images.githubusercontent.com/177266/82331301-0b7fea80-9a38-11ea-8ae6-20ba2f94b706.png)

 
