### PR TITLE
Bug fix: QuerySetSequenceSelectMixin breaks when model uses UUID for PK

### DIFF
--- a/src/dal_queryset_sequence/widgets.py
+++ b/src/dal_queryset_sequence/widgets.py
@@ -26,7 +26,7 @@ class QuerySetSequenceSelectMixin(WidgetMixin):
         ctype_models = {}
 
         for choice in selected_choices:
-            ctype_pk, model_pk = choice.split('-')
+            ctype_pk, model_pk = choice.split('-', 1)
             ctype_pk = int(ctype_pk)
             ctype_models.setdefault(ctype_pk, [])
             ctype_models[ctype_pk].append(model_pk)


### PR DESCRIPTION
If a model is using a UUIDField for its primary key, the QuerySetSequenceSelectMixin breaks on the following line:

`ctype_pk, model_pk = choice.split('-')` as we're expecting a tuple but UUID PK's have additional -'s. This is fixed by forcing the split to only split once. You can see this pattern already in another part of the codebase, i.e. dal_queryset_sequence/fields.py, line 50: 
`return value.split('-', 1) `