### PR TITLE
use backports.functools_lru_cache for lru_cache if available

### DIFF
--- a/src/dal_select2/widgets.py
+++ b/src/dal_select2/widgets.py
@@ -2,8 +2,12 @@
 
 try:
     from functools import lru_cache
-except:
-    lru_cache = None
+except ImportError:
+    # py2
+    try:
+        from backports.functools_lru_cache import lru_cache
+    except ImportError:
+        lru_cache = None
 
 from dal.widgets import (
     QuerySetSelectMixin,
@@ -50,7 +54,7 @@ if lru_cache:
     get_i18n_name = lru_cache()(get_i18n_name)
 else:
     import warnings
-    warnings.warn('Python2: no cache on get_i18n_name until contribution')
+    warnings.warn('Python2: no cache on get_i18n_name, pip install backports.functools-lru-cache')
 
 
 class Select2WidgetMixin(object):

--- a/src/dal_select2/widgets.py
+++ b/src/dal_select2/widgets.py
@@ -54,7 +54,9 @@ if lru_cache:
     get_i18n_name = lru_cache()(get_i18n_name)
 else:
     import warnings
-    warnings.warn('Python2: no cache on get_i18n_name, pip install backports.functools-lru-cache')
+    warnings.warn(
+        'Python2: no cache on get_i18n_name, pip install backports.functools-lru-cache'
+    )
 
 
 class Select2WidgetMixin(object):


### PR DESCRIPTION
I'm working on a project that is still on python <3.3 and I'm seeing a lot of the "Python2: no cache on get_i18n_name until contribution" warnings. It seems like the best way to get rid of these warnings is to use `filterwarnings`. However, it would be nice to still be able to use the `get_i18n_name` caching.

This PR allows python <3.3 users to get rid of the warning and enable the `get_i18n_name` caching by using `lru_cache` from `backports.functools_lru_cache` if it's available.