### PR TITLE
fix Select2GroupQuerySetView

### DIFF
--- a/src/dal/autocomplete.py
+++ b/src/dal/autocomplete.py
@@ -45,6 +45,7 @@ if _installed('dal_select2'):
     )
     from dal_select2.views import (
         Select2QuerySetView,
+        Select2GroupQuerySetView,
         Select2ListView,
         Select2GroupListView
     )

--- a/src/dal_select2/views.py
+++ b/src/dal_select2/views.py
@@ -108,9 +108,9 @@ class Select2GroupQuerySetView(Select2QuerySetView):
             'id': None,
             'text': group,
             'children': [{
-                'id': result.id,
-                'text': getattr(result, self.related_field_name),
-                'title': result.descricao
+                'id': self.get_result_value(result),
+                'text': self.get_result_label(result),
+                'selected_text': self.get_selected_result_label(result),
             } for result in results]
         } for group, results in groups.items()]
 


### PR DESCRIPTION
Hello!

Tried to use this new base view today (PR #1186) but ran into some issues, namely it would crash at [line 113](https://github.com/yourlabs/django-autocomplete-light/blob/master/src/dal_select2/views.py#L113):
```python
'title': result.descricao  # raises AttributeError
```
I suspect that it could be a project-specific property used by the author of original PR, so I though I'd replace it with the methods used throughout the repo to resolve id/text of the resulting items.

Sadly I wasn't able to add some test coverage; in fact I wasn't able to run existing tests either - would love if somebody could guide me as there seem to be quite a lot of setup. That said, I've tested proposed implementation manually and can confirm it works just fine.
