### PR TITLE
#1239 fixes Django 3.2+ Ajax parameter requirements

### DIFF
--- a/src/dal/static/autocomplete_light/autocomplete_light.js
+++ b/src/dal/static/autocomplete_light/autocomplete_light.js
@@ -237,7 +237,10 @@ window.addEventListener("load", function () {
                     data: function (params) {
                         return {
                             term: params.term,
-                            page: params.page
+                            page: params.page,
+                            app_label: $element.data('app-label'),
+                            model_name: $element.data('model-name'),
+                            field_name: $element.data('field-name')
                         };
                     }
                 }


### PR DESCRIPTION
Fixes issue https://github.com/yourlabs/django-autocomplete-light/issues/1239