### PR TITLE
📄 fix(docs): rename `get_result_label` parameter

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -237,8 +237,8 @@ to return HTML code.
     from django.utils.html import format_html
 
     class CountryAutocomplete(autocomplete.Select2QuerySetView):
-        def get_result_label(self, item):
-            return format_html('<img src="flags/{}.png"> {}', item.name, item.name)
+        def get_result_label(self, result):
+            return format_html('<img src="flags/{}.png"> {}', result.name, result.name)
 
 
     class PersonForm(forms.ModelForm):


### PR DESCRIPTION
Overriding the `get_result_label` method requires the second param to be called "result" - not "item".

Otherwise, Pylint throws an arguments-differ error (W0221)