### PR TITLE
Add a possibility to have case-sensitive creates using Select2QuerySetView

### DIFF
--- a/src/dal_select2/views.py
+++ b/src/dal_select2/views.py
@@ -16,6 +16,7 @@ import six
 
 class Select2ViewMixin(object):
     """View mixin to render a JSON response for Select2."""
+    case_sensitive_create = False
 
     def get_results(self, context):
         """Return data for the 'results' key of the response."""
@@ -36,12 +37,17 @@ class Select2ViewMixin(object):
             if page_obj is None or page_obj.number == 1:
                 display_create_option = True
 
-            # Don't offer to create a new option if a
-            # case-insensitive) identical one already exists
-            existing_options = (self.get_result_label(result).lower()
-                                for result in context['object_list'])
-            if q.lower() in existing_options:
-                display_create_option = False
+            if not self.case_sensitive_create:
+                # Don't offer to create a new option if a
+                # case-insensitive) identical one already exists
+                existing_options = (self.get_result_label(result).lower()
+                                    for result in context['object_list'])
+                if q.lower() in existing_options:
+                    display_create_option = False
+            else:
+                existing_options = (self.get_result_label(result) for result in context["object_list"])
+                if q in existing_options:
+                    display_create_option = False
 
         if display_create_option and self.has_add_permission(self.request):
             create_option = [{


### PR DESCRIPTION
Sometimes it desired to have a possibility to create case-sensitive options Select2QuerySetView.

For example image a situation when you are trying to use Select2QuerySetView to choose a unit (e.g. file size).
These units are case-sensitive `MB` vs `Mb`. In current implementation it is not possible to create both `Mb` and `MB` in the search field.

This patch makes it easier to achieve such functionality by overriding Select2QuerySetView.
```python
class CustomSelect2QuerySetView(Select2QuerySetView):
    case_sensitive_create = True
```