### PR TITLE
Fix RemovedInDjango41Warning

### DIFF
--- a/src/dal_select2/__init__.py
+++ b/src/dal_select2/__init__.py
@@ -1,3 +1,5 @@
 """Select2 support for DAL."""
+import django
 
-default_app_config = 'dal_select2.apps.DefaultApp'
+if django.VERSION < (3, 2): # pragma: no cover
+    default_app_config = 'dal_select2.apps.DefaultApp'


### PR DESCRIPTION
RemovedInDjango41Warning: 'dal_select2' defines default_app_config = 'dal_select2.apps.DefaultApp'. Django now detects this configuration automatically. You can remove default_app_config.