### PR TITLE
Fixes an issue when dal is loaded twice

### DIFF
--- a/src/dal/static/autocomplete_light/autocomplete_light.js
+++ b/src/dal/static/autocomplete_light/autocomplete_light.js
@@ -3,7 +3,7 @@
  */
 
 var yl = yl || {};
-yl.functions = {};
+yl.functions = yl.functions || {};
 /**
  * Register your own JS function for DAL.
  *


### PR DESCRIPTION
When dal is initialized multiple times, yl.functions stays set to {} and the select2 function is no longer present. This causes any future dal fields not to render and instead appear as normal HTML select fields. 

This error came up when I tried using HTMX in conjunction with dal. HTMX reloads the form on the fly using ajax calls. When it pulled the new form in and tried to render it, the script tags for dal were loaded again. Thus producing this error.