### PR TITLE
Django 4.0 imports with fallbacks

### DIFF
--- a/src/dal_queryset_sequence/fields.py
+++ b/src/dal_queryset_sequence/fields.py
@@ -6,7 +6,10 @@ from dal_contenttypes.fields import (
 )
 
 from django import forms
-from django.conf.urls import url
+try:
+    from django.urls import re_path as url
+except ImportError:
+    from django.conf.urls import url
 from django.contrib.contenttypes.models import ContentType
 
 from queryset_sequence import QuerySetSequence

--- a/src/dal_queryset_sequence/widgets.py
+++ b/src/dal_queryset_sequence/widgets.py
@@ -8,7 +8,10 @@ from dal.widgets import WidgetMixin
 
 from django import forms
 from django.contrib.contenttypes.models import ContentType
-from django.utils.encoding import force_text
+try:
+    from django.utils.encoding import force_str as force_text
+except ImportError:
+    from django.utils.encoding import force_text
 
 
 class QuerySetSequenceSelectMixin(WidgetMixin):

--- a/src/dal_select2_queryset_sequence/fields.py
+++ b/src/dal_select2_queryset_sequence/fields.py
@@ -5,7 +5,10 @@ from dal_queryset_sequence.fields import QuerySetSequenceModelField
 from dal_select2_queryset_sequence.views import Select2QuerySetSequenceAutoView
 from dal_select2_queryset_sequence.widgets import QuerySetSequenceSelect2
 
-from django.conf.urls import url
+try:
+    from django.urls import re_path as url
+except ImportError:
+    from django.conf.urls import url
 
 from queryset_sequence import QuerySetSequence
 

--- a/test_project/custom_select2/urls.py
+++ b/test_project/custom_select2/urls.py
@@ -1,6 +1,9 @@
 from dal import autocomplete
 
-from django.conf.urls import url
+try:
+    from django.urls import re_path as url
+except ImportError:
+    from django.conf.urls import url
 
 from .models import TModel
 

--- a/test_project/forward_different_fields/urls.py
+++ b/test_project/forward_different_fields/urls.py
@@ -1,6 +1,9 @@
 from dal import autocomplete
 
-from django.conf.urls import url
+try:
+    from django.urls import re_path as url
+except ImportError:
+    from django.conf.urls import url
 
 
 class ListWithForwardsView(autocomplete.Select2ListView):

--- a/test_project/linked_data/urls.py
+++ b/test_project/linked_data/urls.py
@@ -1,6 +1,9 @@
 from dal import autocomplete
 
-from django.conf.urls import url
+try:
+    from django.urls import re_path as url
+except ImportError:
+    from django.conf.urls import url
 
 from .models import TModel
 

--- a/test_project/rename_forward/urls.py
+++ b/test_project/rename_forward/urls.py
@@ -1,6 +1,9 @@
 from dal import autocomplete
 
-from django.conf.urls import url
+try:
+    from django.urls import re_path as url
+except ImportError:
+    from django.conf.urls import url
 
 from .models import TModel
 

--- a/test_project/secure_data/urls.py
+++ b/test_project/secure_data/urls.py
@@ -1,6 +1,9 @@
 from dal import autocomplete
 
-from django.conf.urls import url
+try:
+    from django.urls import re_path as url
+except ImportError:
+    from django.conf.urls import url
 
 from .models import TModel
 

--- a/test_project/select2_djhacker_formfield/urls.py
+++ b/test_project/select2_djhacker_formfield/urls.py
@@ -1,6 +1,9 @@
 from dal import autocomplete
 
-from django.conf.urls import url
+try:
+    from django.urls import re_path as url
+except ImportError:
+    from django.conf.urls import url
 
 from .models import TModel
 

--- a/test_project/select2_foreign_key/urls.py
+++ b/test_project/select2_foreign_key/urls.py
@@ -1,6 +1,9 @@
 from dal import autocomplete
 
-from django.conf.urls import url
+try:
+    from django.urls import re_path as url
+except ImportError:
+    from django.conf.urls import url
 
 from .models import TModel
 

--- a/test_project/select2_generic_foreign_key/urls.py
+++ b/test_project/select2_generic_foreign_key/urls.py
@@ -1,6 +1,9 @@
 # from dal import autocomplete
 
-from django.conf.urls import url
+try:
+    from django.urls import re_path as url
+except ImportError:
+    from django.conf.urls import url
 # from django.contrib.auth.models import Group
 from django.views import generic
 

--- a/test_project/select2_generic_m2m/urls.py
+++ b/test_project/select2_generic_m2m/urls.py
@@ -1,6 +1,9 @@
 from dal import autocomplete
 
-from django.conf.urls import url
+try:
+    from django.urls import re_path as url
+except ImportError:
+    from django.conf.urls import url
 from django.contrib.auth.models import Group
 from django.views import generic
 

--- a/test_project/select2_gm2m/urls.py
+++ b/test_project/select2_gm2m/urls.py
@@ -1,6 +1,9 @@
 from dal import autocomplete
 
-from django.conf.urls import url
+try:
+    from django.urls import re_path as url
+except ImportError:
+    from django.conf.urls import url
 from django.contrib.auth.models import Group
 from django.views import generic
 

--- a/test_project/select2_list/urls.py
+++ b/test_project/select2_list/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls import url
+try:
+    from django.urls import re_path as url
+except ImportError:
+    from django.conf.urls import url
 
 from .views import Select2ListViewAutocomplete, Select2ProvidedValueListViewAutocomplete
 

--- a/test_project/select2_many_to_many/urls.py
+++ b/test_project/select2_many_to_many/urls.py
@@ -1,6 +1,9 @@
 from dal import autocomplete
 
-from django.conf.urls import url
+try:
+    from django.urls import re_path as url
+except ImportError:
+    from django.conf.urls import url
 from django.views import generic
 
 from .forms import TForm

--- a/test_project/select2_nestedadmin/urls.py
+++ b/test_project/select2_nestedadmin/urls.py
@@ -1,6 +1,9 @@
 from dal import autocomplete
 
-from django.conf.urls import url
+try:
+    from django.urls import re_path as url
+except ImportError:
+    from django.conf.urls import url
 
 from .models import TModelThree
 

--- a/test_project/select2_one_to_one/urls.py
+++ b/test_project/select2_one_to_one/urls.py
@@ -1,6 +1,9 @@
 from dal import autocomplete
 
-from django.conf.urls import url
+try:
+    from django.urls import re_path as url
+except ImportError:
+    from django.conf.urls import url
 from django.views import generic
 
 from .forms import TForm

--- a/test_project/select2_outside_admin/urls.py
+++ b/test_project/select2_outside_admin/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls import url
+try:
+    from django.urls import re_path as url
+except ImportError:
+    from django.conf.urls import url
 
 from .views import UpdateView
 

--- a/test_project/select2_tagging/urls.py
+++ b/test_project/select2_tagging/urls.py
@@ -1,6 +1,9 @@
 from dal import autocomplete
 
-from django.conf.urls import url
+try:
+    from django.urls import re_path as url
+except ImportError:
+    from django.conf.urls import url
 
 from tagging.models import Tag
 

--- a/test_project/select2_taggit/urls.py
+++ b/test_project/select2_taggit/urls.py
@@ -1,6 +1,9 @@
 from dal import autocomplete
 
-from django.conf.urls import url
+try:
+    from django.urls import re_path as url
+except ImportError:
+    from django.conf.urls import url
 
 from taggit.models import Tag
 

--- a/test_project/tests/test_widgets.py
+++ b/test_project/tests/test_widgets.py
@@ -9,7 +9,10 @@ import django
 from django import forms
 from django import http
 from django import test
-from django.conf.urls import url
+try:
+    from django.urls import re_path as url
+except ImportError:
+    from django.conf.urls import url
 try:
     from django.urls import reverse
 except ImportError:


### PR DESCRIPTION
This PR fixes more imports for Django 4.0+ while still retaining the old import paths to maximize reverse compatibility.