### PR TITLE
Compatibility with dark mode.

### DIFF
--- a/src/dal_legacy_static/static/admin/css/vendor/select2/select2.css
+++ b/src/dal_legacy_static/static/admin/css/vendor/select2/select2.css
@@ -69,7 +69,8 @@
 .select2-results__option {
   padding: 6px;
   user-select: none;
-  -webkit-user-select: none; }
+  -webkit-user-select: none;
+  color: #000; }
   .select2-results__option[aria-selected] {
     cursor: pointer; }
 
@@ -204,7 +205,8 @@
     float: left;
     margin-right: 5px;
     margin-top: 5px;
-    padding: 0 5px; }
+    padding: 0 5px;
+    color: #000; }
   .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
     color: #999;
     cursor: pointer;


### PR DESCRIPTION
In the dark mode the text color of the selected field is not visible. The dropdown list's text color is also not visible (images attached).

The issue is also mention in #1245 .
<img width="776" alt="Screenshot 2022-01-17 at 3 35 18 PM" src="https://user-images.githubusercontent.com/81680225/149794729-e677be61-7160-4577-8c19-0bd78cc8716a.png">
<img width="812" alt="Screenshot 2022-01-17 at 3 35 02 PM" src="https://user-images.githubusercontent.com/81680225/149794790-7cb8ea89-b1ee-4738-b8f7-5a4848ef5dad.png">
