### PR TITLE
Two isolated unadorned simple test cases added

### DIFF
--- a/test_project/templates/base.html
+++ b/test_project/templates/base.html
@@ -28,6 +28,21 @@
                 >Example using select2 outside the admin</a>
         </li>
     </ul>
+    <p>
+        And here are two very simple unadorned minimalist test pages for
+        isolated inspection and testing.
+    </p>
+    <ul>
+        <li>
+            <a
+                href="{% url 'isolated_dal_single' %}"
+                >A single select widget</a>
+        <li>
+            <a
+                href="{% url 'isolated_dal_multi' %}"
+                >A multi select widget</a>
+        </li>
+    </ul>
 </div>
 <div style="display: inline-block; width: 49%; vertical-align:top;">
     <h2>Need help ?</h2>

--- a/test_project/urls.py
+++ b/test_project/urls.py
@@ -5,12 +5,14 @@ from django.contrib import admin
 
 import views
 
-
 urlpatterns = [
     url(r'^$', views.IndexView.as_view()),
 
     url(r'^admin/', admin.site.urls),
     url(r'^login/', views.LoginView.as_view()),
+
+    url(r'^dal_single/', views.BasicDALView, name='isolated_dal_single'),
+    url(r'^dal_multi/', views.BasicDALMultiView, name='isolated_dal_multi'),
 
     url(r'^secure_data/', include('secure_data.urls')),
     url(r'^linked_data/', include('linked_data.urls')),

--- a/test_project/views.py
+++ b/test_project/views.py
@@ -4,10 +4,79 @@ except ImportError:  # old django, lol it
     from django.views.generic import TemplateView as LoginView
 from django.views import generic
 
+from django.urls import reverse_lazy
+from django.http.response import HttpResponse
+
+from dal import autocomplete
+from select2_many_to_many.models import TModel
+from django.forms.models import ModelChoiceIterator, ModelMultipleChoiceField
+
+
+class LoginView(LoginView):
+    template_name = 'login.html'
+
 
 class IndexView(generic.TemplateView):
     template_name = 'base.html'
 
 
-class LoginView(LoginView):
-    template_name = 'login.html'
+def BasicDALView(request):
+    '''
+    A very basic DAL widget alone on a page for minimalist testing. Not a dressed demo of what DAL can do,
+    rather an isolated functional widget page against which comparisons can be made if someone has a DAL
+    widget not working,
+
+    This is the basic DAL (single selected) widget.
+    '''
+    js = """
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.js" crossorigin="anonymous"></script>
+    """
+    # <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/select2-bootstrap-theme/0.1.0-beta.10/select2-bootstrap.min.css" integrity="sha512-kq3FES+RuuGoBW3a9R2ELYKRywUEQv0wvPTItv3DSGqjpbNtGWVdvT8qwdKkqvPzT93jp8tSF4+oN4IeTEIlQA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    # <script>$.fn.select2.defaults.set( "theme", "bootstrap" );</script>
+    # <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.13/js/select2.full.js" crossorigin="anonymous"></script>
+
+    dal_media = autocomplete.Select2().media
+
+    url = reverse_lazy('select2_many_to_many_autocomplete')
+    field = ModelMultipleChoiceField(TModel.objects.all())
+
+    widget = autocomplete.ModelSelect2(url=url, attrs={"class": "selector", "id": id, "data-placeholder": "Placeholder"})
+    widget.choices = ModelChoiceIterator(field)
+
+    default = None
+    widget_html = widget.render(TModel.__name__, default)
+
+    html = f"<head>{js}\n{dal_media}</head><body><p>{widget_html}</p></body>"
+
+    return HttpResponse(html)
+
+
+def BasicDALMultiView(request):
+    '''
+    A very basic DAL widget alone on a page for minimalist testing. Not a dressed demo of what DAL can do,
+    rather an isolated functional widget page against which comparisons can be made if someone has a DAL
+    widget not working,
+
+    This is the multi select DAL widget.
+    '''
+    js = """
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.js" crossorigin="anonymous"></script>
+    """
+    # <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/select2-bootstrap-theme/0.1.0-beta.10/select2-bootstrap.min.css" integrity="sha512-kq3FES+RuuGoBW3a9R2ELYKRywUEQv0wvPTItv3DSGqjpbNtGWVdvT8qwdKkqvPzT93jp8tSF4+oN4IeTEIlQA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    # <script>$.fn.select2.defaults.set( "theme", "bootstrap" );</script>
+    # <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.13/js/select2.full.js" crossorigin="anonymous"></script>
+
+    dal_media = autocomplete.Select2().media
+
+    url = reverse_lazy('select2_many_to_many_autocomplete')
+    field = ModelMultipleChoiceField(TModel.objects.all())
+
+    widget = autocomplete.ModelSelect2Multiple(url=url, attrs={"class": "selector", "id": id, "data-placeholder": "Placeholder"})
+    widget.choices = ModelChoiceIterator(field)
+
+    default = None
+    widget_html = widget.render(TModel.__name__, default)
+
+    html = f"<head>{js}\n{dal_media}</head><body><p>{widget_html}</p></body>"
+
+    return HttpResponse(html)

--- a/test_project/views.py
+++ b/test_project/views.py
@@ -29,7 +29,7 @@ def BasicDALView(request):
     This is the basic DAL (single selected) widget.
     '''
     js = """
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.js" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.js" crossorigin="anonymous"></script>
     """
     # <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/select2-bootstrap-theme/0.1.0-beta.10/select2-bootstrap.min.css" integrity="sha512-kq3FES+RuuGoBW3a9R2ELYKRywUEQv0wvPTItv3DSGqjpbNtGWVdvT8qwdKkqvPzT93jp8tSF4+oN4IeTEIlQA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     # <script>$.fn.select2.defaults.set( "theme", "bootstrap" );</script>

--- a/test_project/views.py
+++ b/test_project/views.py
@@ -31,16 +31,16 @@ def BasicDALView(request):
     js = """
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.js" crossorigin="anonymous"></script>
     """
-    # <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/select2-bootstrap-theme/0.1.0-beta.10/select2-bootstrap.min.css" integrity="sha512-kq3FES+RuuGoBW3a9R2ELYKRywUEQv0wvPTItv3DSGqjpbNtGWVdvT8qwdKkqvPzT93jp8tSF4+oN4IeTEIlQA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    # <script>$.fn.select2.defaults.set( "theme", "bootstrap" );</script>
-    # <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.13/js/select2.full.js" crossorigin="anonymous"></script>
 
     dal_media = autocomplete.Select2().media
 
     url = reverse_lazy('select2_many_to_many_autocomplete')
     field = ModelMultipleChoiceField(TModel.objects.all())
 
-    widget = autocomplete.ModelSelect2(url=url, attrs={"class": "selector", "id": id, "data-placeholder": "Placeholder"})
+    widget = autocomplete.ModelSelect2(
+        url=url,
+        attrs={"class": "selector", "id": id, "data-placeholder": "Placeholder"})
+
     widget.choices = ModelChoiceIterator(field)
 
     default = None
@@ -71,7 +71,8 @@ def BasicDALMultiView(request):
     url = reverse_lazy('select2_many_to_many_autocomplete')
     field = ModelMultipleChoiceField(TModel.objects.all())
 
-    widget = autocomplete.ModelSelect2Multiple(url=url, attrs={"class": "selector", "id": id, "data-placeholder": "Placeholder"})
+    widget = autocomplete.ModelSelect2Multiple(
+        url=url, attrs={"class": "selector", "id": id, "data-placeholder": "Placeholder"})
     widget.choices = ModelChoiceIterator(field)
 
     default = None


### PR DESCRIPTION
Something sorely lacking from the test_project seems to be a really stripped down, isolated test of the single and multiselect widgets. Very useful and important, I believe, for seeing the very bare minimum configuration for a working widget without a lot of very distracting dressing in templates and views. These a totally drab new pages to demonstrate the stripped down bare minimalist widgets in action.

That said, something is wrong, and this first cut serves as little more than a minimal, stripped down demonstration of the focus bug being discussed (https://github.com/yourlabs/django-autocomplete-light/issues/1283). It is either a DAL bug or an incorrect use of DAL, but this tiny little view will help anyone assessing it to offer commentary on what has gone wrong. There's almost nothing there and hence it is, as per the goal, free of a lot of distracting context.

This is not a complete and form Pull Request, much rather a request for commentary. I do believe there is room for two such supremely simple test cases in the project, BUT of course there may be more enlightened or better implementations (or locations in the file system) of it.  I call this a first cut for commentary and excellently demonstrating the bug mentioned (which may in face be a usage error in and this test illustrates an  implementation that reproduces it).