### PR TITLE
Django version is broken

### DIFF
--- a/test_project/requirements.txt
+++ b/test_project/requirements.txt
@@ -1,4 +1,5 @@
 coverage
+django==3.2
 django-extensions
 django-generic-m2m
 django-gm2m


### PR DESCRIPTION
The test project currently does not work under Django 4. Yet `requirements.txt` produces a venv that won't work because it installs Django 4. We must explicitly select 3.2 until the test project is updated to Django 4 compatibility.