### PR TITLE
Add the option to validate the field when creating a new choice

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -417,7 +417,7 @@ the autocomplete user interface, ie:
     urlpatterns = [
         url(
             r'^country-autocomplete/$',
-            CountryAutocomplete.as_view(create_field='name'),
+            CountryAutocomplete.as_view(create_field='name', validate_create=True),
             name='country-autocomplete',
         ),
     ]
@@ -426,6 +426,9 @@ This way, the option 'Create "Tibet"' will be available if a user inputs
 "Tibet" for example. When the user clicks it, it will make the post request to
 the view which will do ``Country.objects.create(name='Tibet')``. It will be
 included in the server response so that the script can add it to the widget.
+
+By activating ``valide_create=True``, a full_clean will be run on the 
+create_field, thus validating all the validators on the field.
 
 Note that creating objects is allowed to logged-in users with ``add`` permission
 on the resource. If you want to grant ``add`` permission to a user, you have to

--- a/src/dal_select2/static/autocomplete_light/select2.js
+++ b/src/dal_select2/static/autocomplete_light/select2.js
@@ -126,11 +126,19 @@ document.addEventListener('dal-init-function', function () {
                     xhr.setRequestHeader("X-CSRFToken", document.csrftoken);
                 },
                 success: function (data, textStatus, jqXHR) {
-                    select.append(
-                        $('<option>', {value: data.id, text: data.text, selected: true})
-                    );
-                    select.trigger('change');
-                    select.select2('close');
+                    if ('error' in data) {
+                        error = data['error']
+                        $('.dal-create').append(
+                            `<p class="invalid-feedback d-block""><strong>${error}</strong>`
+                        );
+
+                    } else {
+                        select.append(
+                            $('<option>', {value: data.id, text: data.text, selected: true})
+                        );
+                        select.trigger('change');
+                        select.select2('close');
+                    }
                 }
             });
         });

--- a/test_project/select2_one_to_one/models.py
+++ b/test_project/select2_one_to_one/models.py
@@ -1,11 +1,15 @@
 from django.db import models
+from django.core.validators import validate_slug
 
 from six import python_2_unicode_compatible
 
 
 @python_2_unicode_compatible
 class TModel(models.Model):
-    name = models.CharField(max_length=200)
+    name = models.CharField(
+        max_length=200,
+        validators = [validate_slug]
+    )
 
     test = models.OneToOneField(
         'self',

--- a/test_project/select2_one_to_one/urls.py
+++ b/test_project/select2_one_to_one/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
         autocomplete.Select2QuerySetView.as_view(
             model=TModel,
             create_field='name',
+            validate_create=True,
         ),
         name='select2_one_to_one_autocomplete',
     ),


### PR DESCRIPTION
Add the option of validating the data when creating a new option.

Result in the example if we try to create a new option with the added validate_slug 
```
@python_2_unicode_compatible
class TModel(models.Model):
    name = models.CharField(
        max_length=200,
        validators = [validate_slug]
    )
```
![image](https://user-images.githubusercontent.com/5238993/164747538-6b768856-b2ef-4987-8181-7e6fe9c2f481.png)
