### PR TITLE
Add reminder to install django-querysetsequence

### DIFF
--- a/docs/gfk.rst
+++ b/docs/gfk.rst
@@ -61,7 +61,7 @@ Result:
 
 .. code-block:: python
 
-    from dal import autocomplete
+    from dal import autocomplete  # don't forget to pip install django-querysetsequence
 
     class TestForm(autocomplete.FutureModelForm):
 


### PR DESCRIPTION
This mirrors the reminder elsewhere in the documentation "# don't forget to pip install djhacker".  Several issues have been started in the past due to the error that's caused by forgetting (or not understanding) that this isn't installed by default.  e.g. #971.  Just happened to me now.