### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/dal/forms.py
+++ b/src/dal/forms.py
@@ -68,7 +68,7 @@ class FutureModelForm(forms.ModelForm):
       for non-m2m and non-virtual model fields.
     - ``FormField.save_relation_data(instance, name, value)`` should save
       relations required for value on the instance. Called by ``save()``
-      **after** writing the database, when ``instance.pk`` is necessarely set,
+      **after** writing the database, when ``instance.pk`` is necessarily set,
       it overrides ``ModelField.save_form_data()`` which is normally used in
       this occasion for m2m and virtual model fields.
 

--- a/src/dal/test/stories.py
+++ b/src/dal/test/stories.py
@@ -147,7 +147,7 @@ class BaseStory(object):
         el = self.case.browser.find_by_css(sel).first
         el.click()
 
-        # Wait until the form was actually submited
+        # Wait until the form was actually submitted
         tries = 100
         while tries:
             # Popup is gone

--- a/src/dal_queryset_sequence/fields.py
+++ b/src/dal_queryset_sequence/fields.py
@@ -35,7 +35,7 @@ class QuerySetSequenceFieldMixin(object):
         """
         Raise a ValidationError for invalid_choice.
 
-        The validation error left unprecise about the exact error for security
+        The validation error left imprecise about the exact error for security
         reasons, to prevent an attacker doing information gathering to reverse
         valid content type and object ids.
         """

--- a/src/dal_select2_queryset_sequence/views.py
+++ b/src/dal_select2_queryset_sequence/views.py
@@ -93,7 +93,7 @@ class Select2QuerySetSequenceAutoView(Select2QuerySetSequenceView):
                 # (reserved for forwarding fields)
                 pass
 
-            # link the diffrent field by an & query
+            # link the different field by an & query
             and_forward_filtered = reduce(lambda x, y: x & y, forward_filtered)
 
             queryset_models.append(model.objects.filter(and_forward_filtered))


### PR DESCRIPTION
There are small typos in:
- src/dal/forms.py
- src/dal/test/stories.py
- src/dal_queryset_sequence/fields.py
- src/dal_select2_queryset_sequence/views.py

Fixes:
- Should read `necessarily` rather than `necessarely`.
- Should read `submitted` rather than `submited`.
- Should read `imprecise` rather than `unprecise`.
- Should read `different` rather than `diffrent`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md