### PR TITLE
Test Django 4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,18 @@ matrix:
     env: TOXENV=checkqa
   - python: 3.7
     env: TOXENV=docs
+  - python: 3.6
+    env: TOXENV=py36-dj32
   - python: 3.7
-    env: TOXENV=py37-dj30
-  allow_failures:
-  - env: TOXENV=py37-dj30
+    env: TOXENV=py37-dj32
+  - python: 3.8
+    env: TOXENV=py38-dj40
+  - python: 3.8
+    env: TOXENV=py38-dj41
+  - python: 3.9
+    env: TOXENV=py39-dj41
+  - python: 3.10
+    env: TOXENV=py310-dj41
 install:
 - travis_retry pip install -U pip
 - travis_retry pip install tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,9 @@
 [tox]
-# Note that django doesn't support pypy3 for now
-# https://code.djangoproject.com/ticket/25849
-envlist = py{34,35,36,37,38,39,py,py3}-dj{32,40,main}
+envlist =
+    py{36,37,38,39,310,py3}-dj32
+    py{38,39,310,py3}-dj40
+    py{38,39,310,py3}-dj41
+    py{38,39,310,py3}-djmain
 
 [testenv]
 changedir = {toxinidir}/test_project
@@ -11,20 +13,12 @@ setenv =
     DJANGO_SETTINGS_MODULE=settings.base
 
 commands =
-    py.test -v --cov --liveserver 127.0.0.1:9999 {posargs} secure_data rename_forward select2_foreign_key select2_generic_foreign_key select2_list select2_many_to_many select2_one_to_one select2_outside_admin select2_taggit custom_select2 select2_nestedadmin select2_djhacker_formfield
+    pytest -v --cov --liveserver 127.0.0.1:9999 {posargs} secure_data rename_forward select2_foreign_key select2_generic_foreign_key select2_list select2_many_to_many select2_one_to_one select2_outside_admin select2_taggit custom_select2 select2_nestedadmin select2_djhacker_formfield
 
 deps =
-    dj18: Django==1.8.*
-    dj19: Django==1.9.*
-    dj110: Django==1.10.*
-    dj111: Django==1.11.*
-    dj20: Django==2.0.*
-    dj21: Django==2.1.*
-    dj22: Django==2.2.*
-    dj30: Django==3.0.*
-    dj31: Django==3.1.*
-    dj31: Django==3.2.*
-    dj40: Django==4.0.0-rc1
+    dj32: Django==3.2.*
+    dj40: Django==4.0.*
+    dj41: Django==4.1.*
     djmain: https://github.com/django/django/archive/main.tar.gz
     -rtest_project/requirements.txt
 
@@ -32,7 +26,6 @@ passenv = DISPLAY XAUTHORITY XDG_* PIP_* BROWSER MOZ_HEADLESS
 
 [testenv:checkqa]
 changedir = {toxinidir}
-; basepython = python3.6
 commands =
     flake8 --show-source --max-complexity=7 --ignore=W503,D203,E722 --exclude src/dal/autocomplete.py,tests src
     flake8 --show-source --max-complexity=7 --ignore=D203,F401 src/dal/autocomplete.py


### PR DESCRIPTION
This PR updates the tox and travis config files to drop old versions of Django and Python, and test Django 4.1.

I tried running the tests locally. The unit tests pass, but those using splinter fail. It seems pytest-splinter is incompatible with some changes to splinter. I tried rolling back splinter as far as version 0.14, but that only got me different errors. The errors with the latest splinter are all:

```
    @pytest.fixture(scope="session")
    def browser_patches():
        """Browser monkey patches."""
        patch_webdriver()
>       patch_webdriverelement()

../.tox/py310-dj41/lib/python3.10/site-packages/pytest_splinter/plugin.py:278:
_ _ _ 
    def patch_webdriverelement():  # pragma: no cover
        """Patch the WebDriverElement to allow firefox to use mouse_over."""

        def mouse_over(self):
            """Perform a mouse over the element which works."""
            (
                ActionChains(self.parent.driver)
                .move_to_element_with_offset(self._element, 2, 2)
                .perform()
            )

        # Apply the monkey patch for Firefox WebDriverElement
>       firefox.WebDriverElement.mouse_over = mouse_over
E       AttributeError: module 'splinter.driver.webdriver.firefox' has no attribute 'WebDriverElement'
```

I don't think Travis is still running - it hasn't reported any status on this PR. It may need just re-setting up, to use the GitHub app rather than the old token integration. It would be good to move to GitHub Actions anyway, since that's better maintained.