### PR TITLE
Adding dark mode support

### DIFF
--- a/src/dal_select2/static/autocomplete_light/select2.css
+++ b/src/dal_select2/static/autocomplete_light/select2.css
@@ -20,6 +20,23 @@ for light and dark themes.
 The CSS variables were added to Django in 3.2. If they aren't found then we fallback to using the default styles from select2.
 */
 
+/* Create new CSS variable to control the color of the highlighted row
+
+These values will be used for the light theme.
+*/
+.select2-container--default {
+    --select2-highlighted-bg: #5897fb;
+    --select2-highlighted-fg: #fff;
+}
+
+@media (prefers-color-scheme: dark) {
+    /* For dark theme, use the Django selected row color and the body foreground color for the selected row. */
+    .select2-container--default {
+        --select2-highlighted-bg: var(--selected-row, #5897fb);
+        --select2-highlighted-fg: var(--body-fg, #000);
+    }
+}
+
 .select2-dropdown {
     /* The dropdown container where choices are displayed */
     background-color: var(--body-bg, #fff);
@@ -51,14 +68,18 @@ The CSS variables were added to Django in 3.2. If they aren't found then we fall
 
 .select2-container--default .select2-results__option--highlighted[aria-selected] {
     /* The option that is in focus */
-    background-color: var(--selected-row, #5897fb);
-    color: var(--body-fg, #fff);
+    background-color: var(--select2-highlighted-bg, #5897fb);
+    color: var(--select2-highlighted-fg, #fff);
 }
 
 .select2-container--default .select2-selection--multiple .select2-selection__choice {
     /* Selected choices when multiple are allowed */
-    background-color: var(--body-bg, #e4e4e4);
+    background-color: var(--darkened-bg, #e4e4e4);
     border-color: var(--border-color, #aaa);
+}
+
+.select2-container--default .select2-search--inline .select2-search__field {
+    color: var(--body-fg, #000);
 }
 
 .select2-container--default.select2-container--focus .select2-selection--multiple {

--- a/src/dal_select2/static/autocomplete_light/select2.css
+++ b/src/dal_select2/static/autocomplete_light/select2.css
@@ -12,3 +12,55 @@ ul li.select2-search {
     /* Highlight select box with error */
     border-color: #ba2121;
 }
+
+/*
+Add support for using Django CSS variables so that the select2 fields match the look and feel of Django
+for light and dark themes.
+
+The CSS variables were added to Django in 3.2. If they aren't found then we fallback to using the default styles from select2.
+*/
+
+.select2-dropdown {
+    /* The dropdown container where choices are displayed */
+    background-color: var(--body-bg, #fff);
+    border-color: var(--border-color, #aaa);
+}
+
+.select2-container--default .select2-selection {
+    /* The select field input */
+    background-color: var(--body-bg, #fff);
+    border-color: var(--border-color, #aaa);
+}
+
+.select2-container--default .select2-selection .select2-selection__rendered {
+    /* Text for the chosen item when the dropdown is closed */
+    color: var(--body-fg, #444);
+}
+
+.select2-container--default .select2-results__option[aria-selected="true"] {
+    /* The option that has been chosen */
+    background-color: var(--selected-bg, #ddd);
+}
+
+.select2-container--default .select2-search--dropdown .select2-search__field {
+    /* The search input for the choices */
+    background-color: var(--darkened-bg, #fff);
+    border-color: var(--border-color, #aaa);
+    color: var(--body-fg, #000);
+}
+
+.select2-container--default .select2-results__option--highlighted[aria-selected] {
+    /* The option that is in focus */
+    background-color: var(--selected-row, #5897fb);
+    color: var(--body-fg, #fff);
+}
+
+.select2-container--default .select2-selection--multiple .select2-selection__choice {
+    /* Selected choices when multiple are allowed */
+    background-color: var(--body-bg, #e4e4e4);
+    border-color: var(--border-color, #aaa);
+}
+
+.select2-container--default.select2-container--focus .select2-selection--multiple {
+    border-color: var(--border-color, #000);
+}

--- a/src/dal_select2/static/autocomplete_light/select2.css
+++ b/src/dal_select2/static/autocomplete_light/select2.css
@@ -37,7 +37,7 @@ These values will be used for the light theme.
     }
 }
 
-.select2-dropdown {
+.select2-container--default .select2-dropdown {
     /* The dropdown container where choices are displayed */
     background-color: var(--body-bg, #fff);
     border-color: var(--border-color, #aaa);


### PR DESCRIPTION
This fixes #1245 where the select2 fields don't honor the Django dark mode theme.

The fix requires using the CSS variables defined by the Django admin. These variables get used for both dark mode and light mode. For older Django versions < 3.2 before these variables were added, a fallback value is provided that matches the default styling that select2 was using.

Below you can see the comparison between the different fields and their states before and after these changes are applied.

<details><summary>Dark Mode Comparison</summary>
<p>

<details><summary>List comparison</summary>
<p>

## Multiple choice field

### Empty/Inactive

#### Before
<img width="1159" alt="image" src="https://user-images.githubusercontent.com/6753326/191362345-00f78710-9615-49c2-92d7-119a32ba87f3.png">

#### After
<img width="1159" alt="image" src="https://user-images.githubusercontent.com/6753326/191362551-461867cb-5bf3-4ad6-a2a5-6aefffb2f5b7.png">

### Empty and dropdown open

#### Before
<img width="1158" alt="image" src="https://user-images.githubusercontent.com/6753326/191363548-1b9784b7-499b-4a0a-a291-b7a3c63ba53d.png">

#### After
<img width="1157" alt="image" src="https://user-images.githubusercontent.com/6753326/191362833-6f80e6d2-b464-4578-a514-1a941ce9ad93.png">

### 1 selected

#### Before
<img width="1160" alt="image" src="https://user-images.githubusercontent.com/6753326/191363662-882ee8f1-4bc9-410d-ae31-790339e724c9.png">

#### After
<img width="1159" alt="image" src="https://user-images.githubusercontent.com/6753326/191363025-d977d263-069c-47c7-a387-7819a53c3955.png">

### 1 selected and dropdown open

#### Before
<img width="1158" alt="image" src="https://user-images.githubusercontent.com/6753326/191363755-c45646e4-cab6-49d9-97aa-abe7ad926698.png">

#### After
<img width="1159" alt="image" src="https://user-images.githubusercontent.com/6753326/191363152-b8aebcf2-1c42-444f-b69c-d3f0596ac716.png">

### 1 selected and searching

#### Before
<img width="1158" alt="image" src="https://user-images.githubusercontent.com/6753326/191363893-ae6a1e1e-a25c-476f-96c8-9d5aade9c529.png">

#### After
<img width="1158" alt="image" src="https://user-images.githubusercontent.com/6753326/191363345-ca418235-97f8-4169-ba97-8b6e0c9c98ed.png">

## Single choice field

### Empty/Inactive

#### Before
<img width="1157" alt="image" src="https://user-images.githubusercontent.com/6753326/191367186-3f49b11a-b2dc-40ee-ab69-25a38f110756.png">

#### After
<img width="1159" alt="image" src="https://user-images.githubusercontent.com/6753326/191366670-1d750ad1-04c6-41f2-918f-8b176fd2294c.png">

### Empty and dropdown open

#### Before
<img width="1156" alt="image" src="https://user-images.githubusercontent.com/6753326/191367299-e1e88837-57d1-4df8-b6b5-e27501d82c89.png">

#### After
<img width="1155" alt="image" src="https://user-images.githubusercontent.com/6753326/191366863-81bbffd1-e384-430a-b947-b234e9b330eb.png">

### Choice selected

#### Before
<img width="1158" alt="image" src="https://user-images.githubusercontent.com/6753326/191367395-f38d2316-ccfa-4d72-84b4-3deeb92f766e.png">

#### After
<img width="1154" alt="image" src="https://user-images.githubusercontent.com/6753326/191366916-c3342d63-f3b1-490a-a701-99efa3fde7b5.png">

### Choice selected and dropdown open

#### Before
<img width="1157" alt="image" src="https://user-images.githubusercontent.com/6753326/191367464-394cc003-e352-4ca0-a2ab-bc3324ed5ae8.png">

#### After
<img width="1155" alt="image" src="https://user-images.githubusercontent.com/6753326/191366989-4ed49fca-54ce-45ce-a73b-bd86e0275852.png">

### 1 selected and searching

#### Before
<img width="1157" alt="image" src="https://user-images.githubusercontent.com/6753326/191367519-7f854a08-a2a8-4aa6-9ea6-71e1c9bbab42.png">

#### After
<img width="1157" alt="image" src="https://user-images.githubusercontent.com/6753326/191367073-2170cde4-dc69-41c2-94bd-1aba1c31fb3c.png">

</p>
</details>


<details><summary>Table comparison</summary>
<p>

| Field Type | Field State | Before | After |
| --- | --- | --- | --- |
| Multiple Choice | Empty/Inactive | <img width="1159" alt="image" src="https://user-images.githubusercontent.com/6753326/191362345-00f78710-9615-49c2-92d7-119a32ba87f3.png"> | <img width="1159" alt="image" src="https://user-images.githubusercontent.com/6753326/191362551-461867cb-5bf3-4ad6-a2a5-6aefffb2f5b7.png"> |
| Multiple Choice | Empty and dropdown open | <img width="1158" alt="image" src="https://user-images.githubusercontent.com/6753326/191363548-1b9784b7-499b-4a0a-a291-b7a3c63ba53d.png"> | <img width="1157" alt="image" src="https://user-images.githubusercontent.com/6753326/191362833-6f80e6d2-b464-4578-a514-1a941ce9ad93.png"> |
| Multiple Choice | 1 selected | <img width="1160" alt="image" src="https://user-images.githubusercontent.com/6753326/191363662-882ee8f1-4bc9-410d-ae31-790339e724c9.png"> | <img width="1159" alt="image" src="https://user-images.githubusercontent.com/6753326/191363025-d977d263-069c-47c7-a387-7819a53c3955.png"> |
| Multiple Choice | 1 selected and dropdown open | <img width="1158" alt="image" src="https://user-images.githubusercontent.com/6753326/191363755-c45646e4-cab6-49d9-97aa-abe7ad926698.png"> | <img width="1159" alt="image" src="https://user-images.githubusercontent.com/6753326/191363152-b8aebcf2-1c42-444f-b69c-d3f0596ac716.png"> |
| Multiple Choice | 1 selected and searching | <img width="1158" alt="image" src="https://user-images.githubusercontent.com/6753326/191363893-ae6a1e1e-a25c-476f-96c8-9d5aade9c529.png"> | <img width="1158" alt="image" src="https://user-images.githubusercontent.com/6753326/191363345-ca418235-97f8-4169-ba97-8b6e0c9c98ed.png"> |
| Single Choice | Empty/Inactive | <img width="1157" alt="image" src="https://user-images.githubusercontent.com/6753326/191367186-3f49b11a-b2dc-40ee-ab69-25a38f110756.png"> | <img width="1159" alt="image" src="https://user-images.githubusercontent.com/6753326/191366670-1d750ad1-04c6-41f2-918f-8b176fd2294c.png">|
| Single Choice | Empty and dropdown open | <img width="1156" alt="image" src="https://user-images.githubusercontent.com/6753326/191367299-e1e88837-57d1-4df8-b6b5-e27501d82c89.png"> | <img width="1155" alt="image" src="https://user-images.githubusercontent.com/6753326/191366863-81bbffd1-e384-430a-b947-b234e9b330eb.png"> |
| Single Choice | Choice selected | <img width="1158" alt="image" src="https://user-images.githubusercontent.com/6753326/191367395-f38d2316-ccfa-4d72-84b4-3deeb92f766e.png"> | <img width="1154" alt="image" src="https://user-images.githubusercontent.com/6753326/191366916-c3342d63-f3b1-490a-a701-99efa3fde7b5.png"> |
| Single Choice | Choice selected and dropdown open | <img width="1157" alt="image" src="https://user-images.githubusercontent.com/6753326/191367464-394cc003-e352-4ca0-a2ab-bc3324ed5ae8.png"> | <img width="1155" alt="image" src="https://user-images.githubusercontent.com/6753326/191366989-4ed49fca-54ce-45ce-a73b-bd86e0275852.png"> |
| Single Choice | 1 selected and searching | <img width="1157" alt="image" src="https://user-images.githubusercontent.com/6753326/191367519-7f854a08-a2a8-4aa6-9ea6-71e1c9bbab42.png"> | <img width="1157" alt="image" src="https://user-images.githubusercontent.com/6753326/191367073-2170cde4-dc69-41c2-94bd-1aba1c31fb3c.png"> |

</p>
</details>

</p>
</details>


<details><summary>Light Mode Comparison</summary>
<p>

<details><summary>List comparison</summary>
<p>

## Multiple choice

### Empty/Inactive

#### Before
<img width="1158" alt="image" src="https://user-images.githubusercontent.com/6753326/191364452-ddfe1905-8464-4e9c-82bc-0fe72570456a.png">

#### After
<img width="1159" alt="image" src="https://user-images.githubusercontent.com/6753326/191364955-e1dc4892-0142-4e8c-bb02-cef2f49fe73a.png">

### Empty and dropdown open

#### Before
<img width="1156" alt="image" src="https://user-images.githubusercontent.com/6753326/191364518-c154d968-3445-4282-9044-99e635938b9a.png">

#### After
<img width="1157" alt="image" src="https://user-images.githubusercontent.com/6753326/191365028-fe1c10f3-354d-4db3-8196-9251be4e4568.png">

### 1 selected

#### Before
<img width="1155" alt="image" src="https://user-images.githubusercontent.com/6753326/191364572-9f8fdb95-f01a-494c-9786-aa5b355a12ea.png">

#### After
<img width="1157" alt="image" src="https://user-images.githubusercontent.com/6753326/191365089-6dc3fa89-9454-466c-9740-e347004f274b.png">

### 1 selected and dropdown open

#### Before
<img width="1156" alt="image" src="https://user-images.githubusercontent.com/6753326/191364641-390d95bf-e228-477a-8a21-8156eb6bd776.png">

#### After
<img width="1157" alt="image" src="https://user-images.githubusercontent.com/6753326/191365176-49661515-d3b3-4f56-a935-c3a9a87fada9.png">

### 1 selected and searching

#### Before
<img width="1156" alt="image" src="https://user-images.githubusercontent.com/6753326/191364704-2433fc09-a338-4dfe-a3c2-0e43b828cc89.png">

#### After
<img width="1158" alt="image" src="https://user-images.githubusercontent.com/6753326/191365263-d4d076e7-04f9-4fd0-9d9c-e40080711170.png">

## Single choice

### Empty/Inactive

#### Before
<img width="1158" alt="image" src="https://user-images.githubusercontent.com/6753326/191367837-056e8d37-d908-45e4-b92f-e4f3e31d009d.png">

#### After
<img width="1155" alt="image" src="https://user-images.githubusercontent.com/6753326/191368437-228b2865-f056-4196-bb55-27338019861a.png"> 

### Empty and dropdown open

#### Before
<img width="1156" alt="image" src="https://user-images.githubusercontent.com/6753326/191367899-69e966e5-6d55-44f8-9341-4ce1c5653fa4.png">

#### After
<img width="1157" alt="image" src="https://user-images.githubusercontent.com/6753326/191368489-7c23e827-4d30-49f3-bfef-010191e4c672.png">

### Choice selected

#### Before
<img width="1156" alt="image" src="https://user-images.githubusercontent.com/6753326/191367958-678d4a40-396f-4050-a140-6d53f2e4f048.png">

#### After
<img width="1156" alt="image" src="https://user-images.githubusercontent.com/6753326/191368558-11a95cb7-a2c4-4136-8a9c-c12e8f87a974.png">

### Choice selected and dropdown open

#### Before
<img width="1158" alt="image" src="https://user-images.githubusercontent.com/6753326/191368033-5e4be11e-6ef5-4558-877c-42a01e898db4.png">

#### After
<img width="1156" alt="image" src="https://user-images.githubusercontent.com/6753326/191368626-6e816882-3fe9-46a4-ace1-a0d391703f13.png">

### Choice selected and searching

#### Before
<img width="1156" alt="image" src="https://user-images.githubusercontent.com/6753326/191368152-529d612e-075c-42fe-b4ad-c01a14bc7a96.png">

#### After
<img width="1155" alt="image" src="https://user-images.githubusercontent.com/6753326/191368696-bffd1792-588e-41d3-8f76-83938fb862f9.png">

</p>
</details>



<details><summary>Table view</summary>
<p>

| Field Type | Field State | Before | After |
| --- | --- | --- | --- |
| Multiple Choice | Empty/Inactive | <img width="1158" alt="image" src="https://user-images.githubusercontent.com/6753326/191364452-ddfe1905-8464-4e9c-82bc-0fe72570456a.png">  | <img width="1159" alt="image" src="https://user-images.githubusercontent.com/6753326/191364955-e1dc4892-0142-4e8c-bb02-cef2f49fe73a.png">  |
| Multiple Choice | Empty and dropdown open | <img width="1156" alt="image" src="https://user-images.githubusercontent.com/6753326/191364518-c154d968-3445-4282-9044-99e635938b9a.png"> | <img width="1157" alt="image" src="https://user-images.githubusercontent.com/6753326/191365028-fe1c10f3-354d-4db3-8196-9251be4e4568.png"> |
| Multiple Choice | 1 selected | <img width="1155" alt="image" src="https://user-images.githubusercontent.com/6753326/191364572-9f8fdb95-f01a-494c-9786-aa5b355a12ea.png">  | <img width="1157" alt="image" src="https://user-images.githubusercontent.com/6753326/191365089-6dc3fa89-9454-466c-9740-e347004f274b.png"> |
| Multiple Choice | 1 selected and dropdown open | <img width="1156" alt="image" src="https://user-images.githubusercontent.com/6753326/191364641-390d95bf-e228-477a-8a21-8156eb6bd776.png">  | <img width="1157" alt="image" src="https://user-images.githubusercontent.com/6753326/191365176-49661515-d3b3-4f56-a935-c3a9a87fada9.png"> |
| Multiple Choice | 1 selected and searching | <img width="1156" alt="image" src="https://user-images.githubusercontent.com/6753326/191364704-2433fc09-a338-4dfe-a3c2-0e43b828cc89.png"> | <img width="1158" alt="image" src="https://user-images.githubusercontent.com/6753326/191365263-d4d076e7-04f9-4fd0-9d9c-e40080711170.png"> |
| Single Choice | Empty/Inactive | <img width="1158" alt="image" src="https://user-images.githubusercontent.com/6753326/191367837-056e8d37-d908-45e4-b92f-e4f3e31d009d.png"> | <img width="1155" alt="image" src="https://user-images.githubusercontent.com/6753326/191368437-228b2865-f056-4196-bb55-27338019861a.png"> |
| Single Choice | Empty and dropdown open | <img width="1156" alt="image" src="https://user-images.githubusercontent.com/6753326/191367899-69e966e5-6d55-44f8-9341-4ce1c5653fa4.png"> | <img width="1157" alt="image" src="https://user-images.githubusercontent.com/6753326/191368489-7c23e827-4d30-49f3-bfef-010191e4c672.png"> |
| Single Choice | Choice selected | <img width="1156" alt="image" src="https://user-images.githubusercontent.com/6753326/191367958-678d4a40-396f-4050-a140-6d53f2e4f048.png"> | <img width="1156" alt="image" src="https://user-images.githubusercontent.com/6753326/191368558-11a95cb7-a2c4-4136-8a9c-c12e8f87a974.png"> |
| Single Choice | Choice selected and dropdown open | <img width="1158" alt="image" src="https://user-images.githubusercontent.com/6753326/191368033-5e4be11e-6ef5-4558-877c-42a01e898db4.png"> | <img width="1156" alt="image" src="https://user-images.githubusercontent.com/6753326/191368626-6e816882-3fe9-46a4-ace1-a0d391703f13.png"> |
| Single Choice | 1 selected and searching | <img width="1156" alt="image" src="https://user-images.githubusercontent.com/6753326/191368152-529d612e-075c-42fe-b4ad-c01a14bc7a96.png"> | <img width="1155" alt="image" src="https://user-images.githubusercontent.com/6753326/191368696-bffd1792-588e-41d3-8f76-83938fb862f9.png"> |

</p>
</details>

</p>
</details>