### PR TITLE
Use get_result_value when returning created object

### DIFF
--- a/src/dal/views.py
+++ b/src/dal/views.py
@@ -210,6 +210,6 @@ class BaseQuerySetView(ViewMixin, BaseListView):
         result = self.create_object(text)
 
         return http.JsonResponse({
-            'id': result.pk,
+            'id': self.get_result_value(result),
             'text': self.get_selected_result_label(result),
         })


### PR DESCRIPTION
This resolves https://github.com/yourlabs/django-autocomplete-light/issues/1300.

Currently the pk of new object is returned when a new option is created, regardless if you override get_result_value(). 
Use get_result_value() when returning new option from post()