### PR TITLE
Remove 'plugins' from pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,3 @@
 [pytest]
 addopts = --nomigrations --create-db --reuse-db
-plugins = splinter
 DJANGO_SETTINGS_MODULE=settings.base


### PR DESCRIPTION
pytest warns about this key:

```
../.tox/py310-dj42/lib/python3.10/site-packages/_pytest/config/__init__.py:1302
  /Users/chainz/Documents/Projects/django-autocomplete-light/.tox/py310-dj42/lib/python3.10/site-packages/_pytest/config/__init__.py:1302: PytestConfigWarning: Unknown config option: plugins

    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")
```

I thought it might be an old thing but I also can't find mention in the pytest changelog: https://docs.pytest.org/en/stable/changelog.html

Anyway, the tests work without it set, still loading the splinter plugin.