### PR TITLE
Fix Python string escape warning

### DIFF
--- a/test_project/select2_one_to_one/urls.py
+++ b/test_project/select2_one_to_one/urls.py
@@ -18,7 +18,7 @@ urlpatterns = [
         name='select2_one_to_one_autocomplete',
     ),
     url(
-        'test/(?P<pk>\d+)/$',
+        r'test/(?P<pk>\d+)/$',
         generic.UpdateView.as_view(
             model=TModel,
             form_class=TForm,


### PR DESCRIPTION
Fix this warning from the test run:

```
test_project/select2_generic_foreign_key/test_forms.py::GenericFormTest::test_initial
  /.../django-autocomplete-light/test_project/select2_one_to_one/urls.py:21: DeprecationWarning: invalid escape sequence '\d'
    'test/(?P<pk>\d+)/$',
```

Using a raw string is all that's needed. More info: https://adamj.eu/tech/2022/11/04/why-does-python-deprecationwarning-invalid-escape-sequence/ 