### PR TITLE
Fix unittest assertEquals warnings

### DIFF
--- a/src/dal/test/stories.py
+++ b/src/dal/test/stories.py
@@ -280,7 +280,7 @@ class RenameOption(SelectOption):
 
         self.switch_to_popup()
         name_input = self.case.browser.find_by_id('id_name')
-        self.case.assertEquals(
+        self.case.assertEqual(
             name_input['value'],
             current_name
         )
@@ -371,7 +371,7 @@ class MultipleMixin(object):
         for text in texts:
             self.case.assertIn(text, labels)
 
-        self.case.assertEquals(len(texts), len(labels))
+        self.case.assertEqual(len(texts), len(labels))
 
     def assert_values(self, values):
         """Assart that the actual field values matches values."""
@@ -384,7 +384,7 @@ class MultipleMixin(object):
                 text_values
             )
 
-        self.case.assertEquals(len(values), len(actual_values))
+        self.case.assertEqual(len(values), len(actual_values))
 
     def assert_selection(self, values, labels):
         """Assert selections have values and labels."""

--- a/test_project/select2_generic_m2m/test_forms.py
+++ b/test_project/select2_generic_m2m/test_forms.py
@@ -28,7 +28,7 @@ class GenericSelect2TestMixin(object):
         fixture.test = relations
 
     def assert_relation_equals(self, expected, result):
-        self.assertEquals(len(expected), len(result))
+        self.assertEqual(len(expected), len(result))
 
         for o in result:
             self.assertIn(o, expected)
@@ -100,7 +100,7 @@ class GenericM2MFormTest(GenericSelect2TestMixin, test.TestCase):
             fixture.test.connect(r)
 
     def assert_relation_equals(self, expected, result):
-        self.assertEquals(len(expected), len(result))
+        self.assertEqual(len(expected), len(result))
 
         for o in result:
             self.assertIn(o.object, expected)

--- a/test_project/select2_gm2m/test_forms.py
+++ b/test_project/select2_gm2m/test_forms.py
@@ -12,7 +12,7 @@ class GM2MFormTest(GenericSelect2TestMixin, test.TestCase):
     url_name = 'select2_gm2m'
 
     def assert_relation_equals(self, expected, result):
-        self.assertEquals(len(expected), len(result))
+        self.assertEqual(len(expected), len(result))
 
         for o in result:
             self.assertIn(getattr(o, 'gm2m_tgt', o), expected)

--- a/test_project/select2_taggit/test_forms.py
+++ b/test_project/select2_taggit/test_forms.py
@@ -31,7 +31,7 @@ class TagSelect2TestMixin(object):
 
         new = self.tag.objects.get(name=new_tag)
 
-        self.assertEquals(list(result), [existing, new])
+        self.assertEqual(list(result), [existing, new])
 
         self.assertEqual(
             list(self.model.objects.get(pk=instance.pk).test.all()),


### PR DESCRIPTION
Fix these warnings from the test run:

```
test_project/select2_taggit/test_forms.py::TaggitFormTest::test_save
  /.../django-autocomplete-light/test_project/select2_taggit/test_forms.py:34: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(list(result), [existing, new])

test_project/select2_foreign_key/test_functional.py::AdminForeignKeyTestCase::test_can_change_selected_option
test_project/select2_djhacker_formfield/test_functional.py::AdminForeignKeyTestCase::test_can_change_selected_option
  /.../django-autocomplete-light/src/dal/test/stories.py:283: DeprecationWarning: Please use assertEqual instead.
    self.case.assertEquals(
    
test_project/select2_many_to_many/test_functional.py::AdminManyToManyTestCase::test_can_create_option_on_the_fly_and_select_existing_option
test_project/select2_taggit/test_functional.py::TaggitSelect2AdminTest::test_can_select_option_in_first_inline
test_project/select2_taggit/test_functional.py::TaggitSelect2AdminTest::test_can_select_option_in_first_inline
test_project/select2_taggit/test_functional.py::TaggitSelect2AdminTest::test_can_select_options
test_project/select2_taggit/test_functional.py::TaggitSelect2AdminTest::test_can_select_options
  /.../django-autocomplete-light/src/dal/test/stories.py:387: DeprecationWarning: Please use assertEqual instead.
    self.case.assertEquals(len(values), len(actual_values))

test_project/select2_many_to_many/test_functional.py::AdminManyToManyTestCase::test_can_create_option_on_the_fly_and_select_existing_option
test_project/select2_taggit/test_functional.py::TaggitSelect2AdminTest::test_can_select_option_in_first_inline
test_project/select2_taggit/test_functional.py::TaggitSelect2AdminTest::test_can_select_option_in_first_inline
test_project/select2_taggit/test_functional.py::TaggitSelect2AdminTest::test_can_select_options
test_project/select2_taggit/test_functional.py::TaggitSelect2AdminTest::test_can_select_options
  /.../django-autocomplete-light/src/dal/test/stories.py:374: DeprecationWarning: Please use assertEqual instead.
    self.case.assertEquals(len(texts), len(labels))

test_project/select2_taggit/test_forms.py::TaggitFormTest::test_save
  /.../django-autocomplete-light/test_project/select2_taggit/test_forms.py:34: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(list(result), [existing, new])

test_project/select2_foreign_key/test_functional.py::AdminForeignKeyTestCase::test_can_change_selected_option
test_project/select2_djhacker_formfield/test_functional.py::AdminForeignKeyTestCase::test_can_change_selected_option
  /.../django-autocomplete-light/src/dal/test/stories.py:283: DeprecationWarning: Please use assertEqual instead.
    self.case.assertEquals(
```

`assertEquals` has been deprecated since Python 3.2: https://docs.python.org/3/library/unittest.html#deprecated-aliases