### PR TITLE
fix: Fix event format for Django 4.2

### DIFF
--- a/src/dal/static/autocomplete_light/autocomplete_light.js
+++ b/src/dal/static/autocomplete_light/autocomplete_light.js
@@ -284,11 +284,9 @@ window.addEventListener("load", function () {
             $('.admin-autocomplete').not('[name*=__prefix__]').djangoAdminSelect2();
         });
 
-        $(document).on('formset:added', (function () {
-            return function (event, $newFormset) {
-                return $newFormset.find('.admin-autocomplete').djangoAdminSelect2();
-            };
-        })(this));
+        document.addEventListener('formset:added', (event) => {
+            return $(event.target).find('.admin-autocomplete').djangoAdminSelect2();
+        });
     }(django.jQuery));
 
     (function ($, yl) {

--- a/src/dal_legacy_static/static/admin/js/autocomplete.js
+++ b/src/dal_legacy_static/static/admin/js/autocomplete.js
@@ -29,9 +29,7 @@
         $('.admin-autocomplete').not('[name*=__prefix__]').djangoAdminSelect2();
     });
 
-    $(document).on('formset:added', (function() {
-        return function(event, $newFormset) {
-            return $newFormset.find('.admin-autocomplete').djangoAdminSelect2();
-        };
-    })(this));
+    document.addEventListener('formset:added', (event) => {
+      return $(event.target).find('.admin-autocomplete').djangoAdminSelect2();
+    });
 }(django.jQuery));


### PR DESCRIPTION
Event format has been changed for Django 4.2, and old variant isn't working.

https://github.com/django/django/commit/eabc22f919e6c1774842e628400b87ac56c47bce

This PR fixes it, but we need to decide how to handle the old django versions.

Cleaner variant would be to support only latest django version, and those with old version should use old library versions.

If we want to support all django versions, i need to modify this, to check if `$newFormset` is defined or not, and then use two different call variants.

What do you think?