### PR TITLE
Update taggit.rst docs.

### DIFF
--- a/docs/taggit.rst
+++ b/docs/taggit.rst
@@ -48,6 +48,9 @@ Select2 and a QuerySet of Tag objects:
 
             return qs
 
+        def get_create_option(self, context, q):
+            return []
+
 Don't forget to :ref:`register-view`.
 
 .. note:: For more complex filtering, refer to official documentation for


### PR DESCRIPTION
Hi! I ran into this issue and figured out a fix. Maybe this is not the correct change to make or document -- if it isn't, please let me know how to address this in my app + I'd be happy to update the PR to address the underlying code instead if that's the issue.

---

For `taggit` the create option is broken, and it is unnecessary.

One of the drop down options includes the new tag. So if you've typed `funny` and `funny` does not exist you'll have:

```
funny
Create 'funny'
```

Picking `funny` works as intended -- it creates a new tag properly.

Picking `Create 'funny'` creates two tags and labels them wonkily.

This change removes the create option entirely from the docs so this works out of the box for end-users.