### PR TITLE
Fix more string escape warnings

### DIFF
--- a/test_project/select2_generic_foreign_key/urls.py
+++ b/test_project/select2_generic_foreign_key/urls.py
@@ -10,7 +10,7 @@ from .models import TModel
 
 urlpatterns = [
     url(
-        'test/(?P<pk>\d+)/$',
+        r'test/(?P<pk>\d+)/$',
         generic.UpdateView.as_view(
             model=TModel,
             form_class=TForm,

--- a/test_project/select2_many_to_many/urls.py
+++ b/test_project/select2_many_to_many/urls.py
@@ -17,7 +17,7 @@ urlpatterns = [
         name='select2_many_to_many_autocomplete',
     ),
     url(
-        'test/(?P<pk>\d+)/$',
+        r'test/(?P<pk>\d+)/$',
         generic.UpdateView.as_view(
             model=TModel,
             form_class=TForm,


### PR DESCRIPTION
Fix some warnings in the vein of #1326:

```
test_project/select2_generic_foreign_key/test_forms.py::GenericFormTest::test_initial
  /.../test_project/select2_generic_foreign_key/urls.py:13: SyntaxWarning: invalid escape sequence '\d'
    'test/(?P<pk>\d+)/$',

test_project/select2_generic_foreign_key/test_forms.py::GenericFormTest::test_initial
  /.../test_project/select2_many_to_many/urls.py:20: SyntaxWarning: invalid escape sequence '\d'
    'test/(?P<pk>\d+)/$',
```

The warning is `SyntaxWarning` from Python 3.12 onwards, with the aim to remove support soon.