### PR TITLE
Test on Django 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,12 @@ matrix:
     env: TOXENV=py39-dj42
   - python: 3.10
     env: TOXENV=py310-dj42
+  - python: 3.10
+    env: TOXENV=py310-dj50
+  - python: 3.11
+    env: TOXENV=py311-dj50
+  - python: 3.12
+    env: TOXENV=py312-dj50
 install:
 - travis_retry pip install -U pip
 - travis_retry pip install tox

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'Framework :: Django :: 4.0',
         'Framework :: Django :: 4.1',
         'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',

--- a/test_project/requirements.txt
+++ b/test_project/requirements.txt
@@ -3,6 +3,7 @@ django-extensions
 django-generic-m2m
 django-gm2m
 django-querysetsequence
+django-nested-admin
 django-taggit
 django-tagging
 mock
@@ -14,7 +15,6 @@ pytest-cov
 pytest-splinter
 tenacity
 whitenoise
-https://github.com/jpic/django-nested-admin/archive/refs/heads/master.zip#egg=django-nested-admin
 django-debug-toolbar
 sqlparse>=0.4.2 # not directly required, pinned by Snyk to avoid a vulnerability
 djhacker

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@ envlist =
     py{38,39,310,py3}-dj40
     py{38,39,310,py3}-dj41
     py{38,39,310,py3}-dj42
-    py{38,39,310,py3}-djmain
+    py{310,311,312,py3}-dj50
+    py{310,311,312,py3}-djmain
 
 [testenv]
 changedir = {toxinidir}/test_project
@@ -20,7 +21,8 @@ deps =
     dj32: Django==3.2.*
     dj40: Django==4.0.*
     dj41: Django==4.1.*
-    dj41: Django==4.2.*
+    dj42: Django==4.2.*
+    dj50: Django~=5.0b1
     djmain: https://github.com/django/django/archive/main.tar.gz
     -rtest_project/requirements.txt
 


### PR DESCRIPTION
Add official support for this [new Django version](https://docs.djangoproject.com/en/5.0/releases/5.0/), currently in beta. Based on the changes needed back in #1324.

Still working on getting tests running cleanly locally, looks like there are new warnings to fix.