### PR TITLE
WidgetMixin : take the right id in the right place for field forwarding + XSS exploit fix

### DIFF
--- a/src/dal/widgets.py
+++ b/src/dal/widgets.py
@@ -87,7 +87,7 @@ class WidgetMixin(object):
         if self.forward:
             return \
                 '<div style="display:none" class="dal-forward-conf" ' + \
-                'id="dal-forward-conf-for_{id}"'.format(id=id) + \
+                'id="dal-forward-conf-for_{id}"'.format(id=self.attrs.get("id", id)) + \
                 '>' \
                 '<script type="text/dal-forward-conf">' + \
                 json.dumps(

--- a/src/dal_select2/static/autocomplete_light/select2.js
+++ b/src/dal_select2/static/autocomplete_light/select2.js
@@ -30,7 +30,9 @@ document.addEventListener('dal-init-function', function () {
                 return $result.text(item.text);
               }
             } else {
-                return template(item.text, is_data_html);
+                let text = item.text;
+                if (item.selected) text = escape(text);
+                return template(text, is_data_html);
             }
         }
 


### PR DESCRIPTION
Actually, for field forwarding, there is a mismatch between the div `id` given at python side and the `id` at javascript side. At python side the widget `id` is not read at the right place.

In the PR there is a very quick fix for that.

There is also a XSS exploit possible in select2.js when displaying selected item : it requires to be escaped.