### PR TITLE
#1333 clone forwards

### DIFF
--- a/src/dal/widgets.py
+++ b/src/dal/widgets.py
@@ -47,9 +47,17 @@ class WidgetMixin(object):
     def __init__(self, url=None, forward=None, *args, **kwargs):
         """Instanciate a widget with a URL and a list of fields to forward."""
         self.url = url
-        self.forward = forward or []
+        if forward:
+            self.forward = list(forward).copy()
+        else:
+            self.forward = []
         self.placeholder = kwargs.get("attrs", {}).get("data-placeholder")
         super(WidgetMixin, self).__init__(*args, **kwargs)
+
+    def __deepcopy__(self, memo):
+        clone = super().__deepcopy__(memo)
+        clone.forward = self.forward.copy()
+        return clone
 
     def build_attrs(self, *args, **kwargs):
         """Build HTML attributes for the widget."""


### PR DESCRIPTION
When Django creates a Form instance from a form class, the fields and widgets are _copied_ instead of instantiated. This means that every field/widget must implement __deepcopy__ properly to create clones of any references it holds.

Implement `__deepcopy__` in the `WidgetMixin` and copy the `forward` list to prevent forwards from leaking into unrelated forms when using a common base class.