### PR TITLE
Fix - Object of type ValidationError is not JSON serializable

### DIFF
--- a/src/dal/views.py
+++ b/src/dal/views.py
@@ -16,6 +16,7 @@ from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.db.models import Q
 from django.http import HttpResponseBadRequest, HttpResponseNotAllowed
 from django.template.loader import render_to_string
+from django.utils.translation import gettext_lazy as _
 from django.views.generic.list import BaseListView
 
 
@@ -201,7 +202,7 @@ class BaseQuerySetView(ViewMixin, BaseListView):
                 self.validate(text)
             except ValidationError as error:
                 if self.create_field in error.message_dict:
-                    return http.JsonResponse(dict(error=error))
+                    return http.JsonResponse(dict(error=error.message_dict.get(self.create_field, _('Error'))))
 
         result = self.create_object(text)
 


### PR DESCRIPTION
On [Creation of new choices in the autocomplete form](https://django-autocomplete-light.readthedocs.io/en/master/tutorial.html#creation-of-new-choices-in-the-autocomplete-form), when we use `validate_create=True` and the validation failed we have `TypeError: Object of type ValidationError is not JSON serializable`.

Corrections made :
- fix the TypeError
- return of the error of the concerned field to the view

Versions used:
- django==5.0.7
- django-autocomplete-light==3.11.0