### PR TITLE
build and release wheel

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -36,7 +36,7 @@ echo -e "$(python changelog.py $1)\n$(cat CHANGELOG)" > CHANGELOG
 git add setup.py docs/conf.py CHANGELOG
 git commit -m "Release $1"
 git tag $1
-python setup.py sdist
+python -m build
 twine upload dist/django_autocomplete_light-${1/-/}.tar.gz
 git push origin master $1
 


### PR DESCRIPTION
Direct invocation of setuptools is [deprecated](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/).  Build and publish a wheel.

I did not see where you set up dependencies for build/publish: you will need to `pip install build` before building (just as you need to `pip install twine` before publishing).