### PR TITLE
super(..) -> super()

### DIFF
--- a/src/dal/forms.py
+++ b/src/dal/forms.py
@@ -77,7 +77,7 @@ class FutureModelForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         """Override that uses a form field's ``value_from_object()``."""
-        super(FutureModelForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         for name, field in self.fields.items():
             if not hasattr(field, 'value_from_object'):
@@ -87,7 +87,7 @@ class FutureModelForm(forms.ModelForm):
 
     def _post_clean(self):
         """Override that uses the form field's ``save_object_data()``."""
-        super(FutureModelForm, self)._post_clean()
+        super()._post_clean()
 
         for name, field in self.fields.items():
             if not hasattr(field, 'save_object_data'):

--- a/src/dal/forward.py
+++ b/src/dal/forward.py
@@ -58,7 +58,7 @@ class Field(Forward):
 
     def to_dict(self):
         """Convert to dictionary which will be rendered as JSON."""
-        d = super(Field, self).to_dict()
+        d = super().to_dict()
 
         d.update(src=self.src)
         if self.dst is not None:
@@ -88,7 +88,7 @@ class Const(Forward):
 
     def to_dict(self):
         """Convert to dictionary which will be rendered as JSON."""
-        d = super(Const, self).to_dict()
+        d = super().to_dict()
 
         d.update(val=self.val)
         d.update(dst=self.dst)
@@ -132,7 +132,7 @@ class JavaScript(Forward):
 
     def to_dict(self):
         """Convert to dictionary which will be rendered as JSON."""
-        d = super(JavaScript, self).to_dict()
+        d = super().to_dict()
 
         d.update(handler=self.handler)
         d.update(dst=self.dst)
@@ -161,7 +161,7 @@ class Self(Forward):
 
     def to_dict(self):
         """Convert to dictionary which will be rendered as JSON."""
-        d = super(Self, self).to_dict()
+        d = super().to_dict()
 
         if self.dst is not None:
             d.update(dst=self.dst)

--- a/src/dal/test/case.py
+++ b/src/dal/test/case.py
@@ -99,6 +99,6 @@ class ContentTypeOptionMixin(OptionMixin):
 
     def create_option(self):
         """Return option, content type."""
-        option = super(ContentTypeOptionMixin, self).create_option()
+        option = super().create_option()
         ctype = ContentType.objects.get_for_model(option)
         return option, ctype

--- a/src/dal/test/stories.py
+++ b/src/dal/test/stories.py
@@ -234,7 +234,7 @@ class InlineSelectOption(SelectOption):
         self.inline_related_name = (inline_related_name
                                     or case.inline_related_name)
 
-        super(InlineSelectOption, self).__init__(case, **kwargs)
+        super().__init__(case, **kwargs)
 
         self.field_container_selector = '#%s-%s .field-%s' % (
             self.inline_related_name, self.inline_number, self.field_name)
@@ -411,7 +411,7 @@ class InlineSelectOptionMultiple(MultipleMixin, InlineSelectOption):
     def __init__(self, case, inline_number, inline_related_name=None,
                  **kwargs):
         """Set input_selector with field_container_selector."""
-        super(InlineSelectOptionMultiple, self).__init__(
+        super().__init__(
             case,
             inline_number,
             inline_related_name=inline_related_name,

--- a/src/dal/views.py
+++ b/src/dal/views.py
@@ -55,7 +55,7 @@ class ViewMixin(object):
             return HttpResponseBadRequest('Not a JSON object')
 
         self.q = request.GET.get('q', '')
-        return super(ViewMixin, self).dispatch(request, *args, **kwargs)
+        return super().dispatch(request, *args, **kwargs)
 
 
 class BaseQuerySetView(ViewMixin, BaseListView):
@@ -105,7 +105,7 @@ class BaseQuerySetView(ViewMixin, BaseListView):
 
     def get_queryset(self):
         """Filter the queryset with GET['q']."""
-        qs = super(BaseQuerySetView, self).get_queryset()
+        qs = super().get_queryset()
 
         qs = self.get_search_results(qs, self.q)
 

--- a/src/dal/widgets.py
+++ b/src/dal/widgets.py
@@ -49,11 +49,11 @@ class WidgetMixin(object):
         self.url = url
         self.forward = forward or []
         self.placeholder = kwargs.get("attrs", {}).get("data-placeholder")
-        super(WidgetMixin, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def build_attrs(self, *args, **kwargs):
         """Build HTML attributes for the widget."""
-        attrs = super(WidgetMixin, self).build_attrs(*args, **kwargs)
+        attrs = super().build_attrs(*args, **kwargs)
 
         if self.url is not None:
             attrs['data-autocomplete-light-url'] = self.url
@@ -120,7 +120,7 @@ class WidgetMixin(object):
             if self.placeholder:
                 self.choices.insert(0, (None, ""))
 
-        html = super(WidgetMixin, self).render_options(*args)
+        html = super().render_options(*args)
 
         self.choices = all_choices
 
@@ -140,13 +140,13 @@ class WidgetMixin(object):
         elif not self.allow_multiple_selected:
             if self.placeholder:
                 self.choices.insert(0, (None, ""))
-        result = super(WidgetMixin, self).optgroups(name, value, attrs)
+        result = super().optgroups(name, value, attrs)
         self.choices = all_choices
         return result
 
     def render(self, name, value, attrs=None, renderer=None, **kwargs):
         """Call Django render together with `render_forward_conf`."""
-        widget = super(WidgetMixin, self).render(name, value, attrs, **kwargs)
+        widget = super().render(name, value, attrs, **kwargs)
         try:
             field_id = attrs['id']
         except (KeyError, TypeError):

--- a/src/dal_contenttypes/fields.py
+++ b/src/dal_contenttypes/fields.py
@@ -39,7 +39,7 @@ class ContentTypeModelMultipleFieldMixin(ContentTypeModelFieldMixin):
             return []
 
         return [
-            super(ContentTypeModelMultipleFieldMixin, self).prepare_value(v)
+            super().prepare_value(v)
             for v in value
         ]
 

--- a/src/dal_queryset_sequence/fields.py
+++ b/src/dal_queryset_sequence/fields.py
@@ -160,7 +160,7 @@ class GenericForeignKeyModelField(QuerySetSequenceModelField):
             raise AttributeError(
                 "Class object are required (not instantiated)")
 
-        super(GenericForeignKeyModelField, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def as_url(self, form):
         """Return url."""

--- a/src/dal_queryset_sequence/tests/test_views.py
+++ b/src/dal_queryset_sequence/tests/test_views.py
@@ -21,7 +21,7 @@ class Select2QuerySetSequenceViewTestCase(test.TestCase):
             Group.objects.create(name='ViewTestCase%s' % i)
 
         cls.request = test.RequestFactory().get('?q=foo')
-        super(Select2QuerySetSequenceViewTestCase, cls).setUpClass()
+        super().setUpClass()
 
     def get_view(self, **kwargs):
         view = autocomplete.Select2QuerySetSequenceView(

--- a/src/dal_queryset_sequence/views.py
+++ b/src/dal_queryset_sequence/views.py
@@ -31,7 +31,7 @@ class BaseQuerySetSequenceView(BaseQuerySetView):
         if self.mixup:
             return False
 
-        return super(BaseQuerySetSequenceView, self).has_more(context)
+        return super().has_more(context)
 
     def mixup_querysets(self, qs):
         """Return a queryset with different model types."""
@@ -44,7 +44,7 @@ class BaseQuerySetSequenceView(BaseQuerySetView):
 
     def get_queryset(self):
         """Mix results from all querysets in QuerySetSequence if self.mixup."""
-        qs = super(BaseQuerySetSequenceView, self).get_queryset()
+        qs = super().get_queryset()
 
         if self.mixup:
             qs = self.mixup_querysets(qs)

--- a/src/dal_select2/fields.py
+++ b/src/dal_select2/fields.py
@@ -38,7 +38,7 @@ class Select2ListChoiceField(ChoiceField):
         """
         choices = ChoiceCallable(choice_list)
 
-        super(Select2ListChoiceField, self).__init__(
+        super().__init__(
             choices=choices, required=required, widget=widget, label=label,
             initial=initial, help_text=help_text, *args, **kwargs
         )
@@ -49,4 +49,4 @@ class Select2ListCreateChoiceField(Select2ListChoiceField):
 
     def validate(self, value):
         """Do not validate choices but check for empty."""
-        super(ChoiceField, self).validate(value)
+        super().validate(value)

--- a/src/dal_select2/widgets.py
+++ b/src/dal_select2/widgets.py
@@ -71,7 +71,7 @@ class Select2WidgetMixin(object):
 
     def build_attrs(self, *args, **kwargs):
         """Set data-autocomplete-light-language."""
-        attrs = super(Select2WidgetMixin, self).build_attrs(*args, **kwargs)
+        attrs = super().build_attrs(*args, **kwargs)
         lang_code = self._get_language_code()
         if lang_code:
             attrs.setdefault('data-autocomplete-light-language', lang_code)
@@ -144,7 +144,7 @@ class TagSelect2(WidgetMixin,
 
     def build_attrs(self, *args, **kwargs):
         """Automatically set data-tags=1."""
-        attrs = super(TagSelect2, self).build_attrs(*args, **kwargs)
+        attrs = super().build_attrs(*args, **kwargs)
         attrs.setdefault('data-tags', 1)
         return attrs
 
@@ -154,7 +154,7 @@ class TagSelect2(WidgetMixin,
         This is needed because Select2 uses a multiple select even in tag mode,
         and the model field expects a comma-separated list of tags.
         """
-        values = super(TagSelect2, self).value_from_datadict(data, files, name)
+        values = super().value_from_datadict(data, files, name)
         return ','.join(values)
 
     def option_value(self, value):

--- a/src/dal_select2_queryset_sequence/fields.py
+++ b/src/dal_select2_queryset_sequence/fields.py
@@ -41,7 +41,7 @@ class Select2GenericForeignKeyModelField(QuerySetSequenceModelField):
                                for model in model_choice]
             kwargs['queryset'] = QuerySetSequence(*models_queryset)
 
-        super(Select2GenericForeignKeyModelField, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def as_url(self, form):
         """Return url."""

--- a/src/dal_select2_taggit/widgets.py
+++ b/src/dal_select2_taggit/widgets.py
@@ -10,7 +10,7 @@ class TaggitSelect2(TagSelect2):
 
     def build_attrs(self, *args, **kwargs):
         """Add data-tags=","."""
-        attrs = super(TaggitSelect2, self).build_attrs(*args, **kwargs)
+        attrs = super().build_attrs(*args, **kwargs)
         attrs['data-tags'] = ','
         return attrs
 
@@ -20,7 +20,7 @@ class TaggitSelect2(TagSelect2):
         Insure there's a comma when there's only a single multi-word tag,
         or tag "Multi word" would end up as "Multi" and "word".
         """
-        value = super(TaggitSelect2, self).value_from_datadict(data,
+        value = super().value_from_datadict(data,
                                                                files, name)
         if value and ',' not in value:
             value = '%s,' % value

--- a/test_project/custom_select2/test_functional.py
+++ b/test_project/custom_select2/test_functional.py
@@ -13,6 +13,6 @@ class AdminForeignKeyTestCase(Select2Story, case.AdminMixin, case.OptionMixin,
     model = TModel
 
     def setUp(self):
-        super(AdminForeignKeyTestCase, self).setUp()
+        super().setUp()
         self.get(url=self.get_modeladmin_url('add'))
         self.fill_name()

--- a/test_project/custom_select2/widgets.py
+++ b/test_project/custom_select2/widgets.py
@@ -8,6 +8,6 @@ class TModelSelect2(ModelSelect2):
 
     @property
     def media(self):
-        base_media = super(TModelSelect2, self).media
+        base_media = super().media
         custom_media = forms.Media(js=('t_select2.js',))
         return base_media + custom_media

--- a/test_project/linked_data/test_forms.py
+++ b/test_project/linked_data/test_forms.py
@@ -10,7 +10,7 @@ class LinkedDataFormTest(test.TestCase):  # noqa
     """Linked data form test."""
 
     def setUp(self):
-        super(LinkedDataFormTest, self).setUp()
+        super().setUp()
         User = apps.get_model('auth.user')  # noqa
         self.owner, c = User.objects.get_or_create(
             username='owner'

--- a/test_project/linked_data/test_functional.py
+++ b/test_project/linked_data/test_functional.py
@@ -15,7 +15,7 @@ class AdminLinkedDataTest(Select2Story,
     model = TModel
 
     def setUp(self):
-        super(AdminLinkedDataTest, self).setUp()
+        super().setUp()
 
         if not getattr(self, 'fixtures', None):
             self.fixtures = OwnedFixtures()

--- a/test_project/linked_data/urls.py
+++ b/test_project/linked_data/urls.py
@@ -7,7 +7,7 @@ from .models import TModel
 
 class LinkedDataView(autocomplete.Select2QuerySetView):
     def get_queryset(self):
-        qs = super(LinkedDataView, self).get_queryset()
+        qs = super().get_queryset()
         owner = self.forwarded.get('owner', None)
 
         if owner:

--- a/test_project/rename_forward/urls.py
+++ b/test_project/rename_forward/urls.py
@@ -7,7 +7,7 @@ from .models import TModel
 
 class LinkedDataView(autocomplete.Select2QuerySetView):
     def get_queryset(self):
-        qs = super(LinkedDataView, self).get_queryset()
+        qs = super().get_queryset()
 
         possessor = self.forwarded.get('possessor', None)
         secret = self.forwarded.get('secret', None)

--- a/test_project/secure_data/admin.py
+++ b/test_project/secure_data/admin.py
@@ -6,7 +6,7 @@ from .models import TModel
 
 class SecureFormMixin(object):
     def get_form(self, request, obj=None, **kwargs):
-        form = super(SecureFormMixin, self).get_form(
+        form = super().get_form(
             request, obj=obj, **kwargs)
 
         # Create a copy of the class so that we can hack the field definition

--- a/test_project/secure_data/test_functional.py
+++ b/test_project/secure_data/test_functional.py
@@ -13,7 +13,7 @@ class AdminLinkedDataTest(Select2Story, case.AdminMixin, case.OptionMixin,
     model = TModel
 
     def setUp(self):
-        super(AdminLinkedDataTest, self).setUp()
+        super().setUp()
 
         if not getattr(self, 'fixtures', None):
             self.fixtures = OwnedFixtures()

--- a/test_project/select2_foreign_key/test_functional.py
+++ b/test_project/select2_foreign_key/test_functional.py
@@ -13,7 +13,7 @@ class AdminForeignKeyTestCase(Select2Story, case.AdminMixin, case.OptionMixin,
     model = TModel
 
     def setUp(self):
-        super(AdminForeignKeyTestCase, self).setUp()
+        super().setUp()
         self.get(url=self.get_modeladmin_url('add'))
         self.fill_name()
 

--- a/test_project/select2_generic_foreign_key/test_functional.py
+++ b/test_project/select2_generic_foreign_key/test_functional.py
@@ -14,7 +14,7 @@ class AdminGenericForeignKeyTestCase(Select2Story, case.AdminMixin,
     model = TModel
 
     def setUp(self):
-        super(AdminGenericForeignKeyTestCase, self).setUp()
+        super().setUp()
         self.get(url=self.get_modeladmin_url('add'))
 
     def test_can_select_option(self):

--- a/test_project/select2_generic_m2m/test_functional.py
+++ b/test_project/select2_generic_m2m/test_functional.py
@@ -10,7 +10,7 @@ class AdminGenericM2MBase(object):
     inline_related_name = 'inline_test_models'
 
     def setUp(self):
-        super(AdminGenericM2MBase, self).setUp()
+        super().setUp()
         self.get(url=self.get_modeladmin_url('add'))
         self.fill_name()
 

--- a/test_project/select2_list/test_functional.py
+++ b/test_project/select2_list/test_functional.py
@@ -19,14 +19,14 @@ class AdminSelect2List(Select2Story, case.AdminMixin, case.OptionMixin,
 
     def create_option(self):
         """Return option, content type."""
-        option = super(AdminSelect2List, self).create_option()
+        option = super().create_option()
         option.test = random_text()
         option.save()
 
         return option
 
     def setUp(self):
-        super(AdminSelect2List, self).setUp()
+        super().setUp()
         self.get(url=self.get_modeladmin_url('add'))
         self.fill_name()
 

--- a/test_project/select2_many_to_many/test_functional.py
+++ b/test_project/select2_many_to_many/test_functional.py
@@ -15,7 +15,7 @@ class AdminManyToManyTestCase(Select2Story, case.AdminMixin, case.OptionMixin,
     label_selector = '.select2-selection__choice'
 
     def setUp(self):
-        super(AdminManyToManyTestCase, self).setUp()
+        super().setUp()
         self.get(url=self.get_modeladmin_url('add'))
 
     def test_can_create_option_on_the_fly_and_select_existing_option(self):

--- a/test_project/select2_nestedadmin/test_functional.py
+++ b/test_project/select2_nestedadmin/test_functional.py
@@ -15,7 +15,7 @@ class AdminNestedLinkedDataTest(Select2Story,
     model = TModelOne
 
     def setUp(self):
-        super(AdminNestedLinkedDataTest, self).setUp()
+        super().setUp()
         self.get(url=self.get_modeladmin_url('add'))
         self.fill_name()
 

--- a/test_project/select2_nestedadmin/urls.py
+++ b/test_project/select2_nestedadmin/urls.py
@@ -20,7 +20,7 @@ class LinkedDataView(autocomplete.Select2QuerySetView):
             raise NestedAdminError(
                 'Linked fields are not forwarded properly for nested admin')
 
-        return super(LinkedDataView, self).get_queryset()
+        return super().get_queryset()
 
 
 urlpatterns = [

--- a/test_project/select2_one_to_one/test_functional.py
+++ b/test_project/select2_one_to_one/test_functional.py
@@ -15,7 +15,7 @@ class AdminOneToOneTestCase(Select2Story, case.AdminMixin, case.OptionMixin,
     model = TModel
 
     def setUp(self):
-        super(AdminOneToOneTestCase, self).setUp()
+        super().setUp()
         self.get(url=self.get_modeladmin_url('add'))
 
     def test_can_create_option_on_the_fly(self):

--- a/test_project/select2_tagging/test_functional.py
+++ b/test_project/select2_tagging/test_functional.py
@@ -9,7 +9,7 @@ from .models import TModel
 
 class TagSelect2AdminTestMixin(Select2Story, case.AdminMixin):
     def setUp(self):
-        super(TagSelect2AdminTestMixin, self).setUp()
+        super().setUp()
         self.get(url=self.get_modeladmin_url('add'))
         self.fill_name()
 

--- a/test_project/select2_taggit/test_functional.py
+++ b/test_project/select2_taggit/test_functional.py
@@ -9,7 +9,7 @@ from .models import TModel
 
 class TagSelect2AdminTestMixin(Select2Story, case.AdminMixin):
     def setUp(self):
-        super(TagSelect2AdminTestMixin, self).setUp()
+        super().setUp()
         self.get(url=self.get_modeladmin_url('add'))
         self.fill_name()
 


### PR DESCRIPTION
Probably less error prone, since all are how the [PEP-3135](https://peps.python.org/pep-3135/) specifies it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined internal code by adopting modern syntax for class initializations and method calls, improving readability and long-term maintainability without changing functionality.
  
- **Tests**
  - Updated test setups and configurations to reflect these improvements, ensuring consistent behavior and enhanced code clarity across the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->