### PR TITLE
fix: include static files in wheel and fix formset template for Django 5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ nested = ["django-nested-admin>=3.0.21"]
 tags = ["django-taggit"]
 gfk = ["django-querysetsequence>=0.11"]
 
+[tool.setuptools]
+include-package-data = true
+
 [tool.setuptools.packages.find]
 where = ["src"]
 

--- a/test_project/select2_outside_admin/templates/select2_outside_admin.html
+++ b/test_project/select2_outside_admin/templates/select2_outside_admin.html
@@ -8,13 +8,13 @@
         {% csrf_token %}
         {{ form.as_p }}
 
-        <table style="display: none">
+        <div style="display: none" class="formset-empty">
             {{ view.formset.empty_form }}
-        </table>
+        </div>
 
-        <table>
+        <div class="formset-rows">
             {{ view.formset }}
-        </table>
+        </div>
 
         <span id="add-form" class="button">Add form</span>
 
@@ -32,19 +32,20 @@
 (function($) {
     $('#add-form').click(function() {
         var index = $('#id_inline_test_models-TOTAL_FORMS').val()
-        var newTable = $('#id_inline_test_models-__prefix__-DELETE').parents('table').clone()
-        newTable.find(':input').each(function() {
+        var newForm = $('#id_inline_test_models-__prefix__-DELETE').closest('.formset-empty').clone()
+        newForm.find(':input').each(function() {
             for (attr of ['name', 'id'])
                 $(this).attr(
                     attr,
                     $(this).attr(attr).replace('__prefix__', index)
                 )
         })
-        newTable.insertBefore($(this))
+        newForm.removeAttr('style').removeClass('formset-empty')
+        newForm.insertBefore($(this))
         $('#id_inline_test_models-TOTAL_FORMS').val(
             parseInt($('#id_inline_test_models-TOTAL_FORMS').val()) + 1
         )
-        newTable.slideDown()
+        newForm.slideDown()
     })
 })($)
 </script>


### PR DESCRIPTION
## Problem

Two issues were found by testing the release experience with a clean wheel install (`python3 -m build` → `pip install dist/*.whl`):

### 1. Widget not loading at `/select2_outside_admin/`

`pyproject.toml` was missing `include-package-data = true`. Without it, setuptools only bundles `.py` files in the wheel — all static assets (JS, CSS, Select2 i18n files) were absent from the installed package.

This is invisible with `pip install -e .` (editable install symlinks the full source tree) but breaks for end users installing from PyPI.

### 2. Template form visible due to Django 5 rendering change

Django 5 changed form rendering from `<p>` / `<tr>` to `<div>`. The `select2_outside_admin` template was wrapping `formset.empty_form` in `<table style="display: none">`. Since `<div>` inside `<table>` is invalid HTML, browsers hoist the divs outside the table, making the `__prefix__` template fields visible on the page.

The same issue also broke the "Add form" button, whose JS used `parents('table')` to locate the template — a selector that no longer worked after the divs were hoisted.

## Fix

- `pyproject.toml`: add `[tool.setuptools] include-package-data = true`
- `select2_outside_admin.html`: replace `<table>` wrappers with `<div>`, update JS selector from `parents('table')` to `closest('.formset-empty')`

## Test procedure

```bash
python3 -m build
python3 -m venv env && source env/bin/activate
pip install dist/django_autocomplete_light-4.0.0-py3-none-any.whl
cd test_project && pip install -r requirements.txt
./manage.py migrate && ./manage.py runserver
```

- `http://localhost:8000/select2_outside_admin/` — Select2 widget loads, no ghost `__prefix__` fields visible
- "Add form" button correctly clones and appends a new inline form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated build configuration to ensure package data is included during distribution.

* **Refactor**
  * Restructured form container markup with improved semantic HTML.
  * Enhanced form element cloning behavior and animation sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->