### PR TITLE
docs: fix stale alight-backend branch links to master

### DIFF
--- a/docs/_forward.rst
+++ b/docs/_forward.rst
@@ -2,7 +2,7 @@ Filtering results based on other form fields (forwarding)
 =========================================================
 
 - Example source: `test_project/alight_linked_data
-  <https://github.com/yourlabs/django-autocomplete-light/tree/alight-backend/test_project/alight_linked_data>`_
+  <https://github.com/yourlabs/django-autocomplete-light/tree/master/test_project/alight_linked_data>`_
 - Live demo: `Admin / Alight Linked Data / Add
   <http://localhost:8000/admin/alight_linked_data/tmodel/add/>`_
 

--- a/docs/alight.rst
+++ b/docs/alight.rst
@@ -56,7 +56,7 @@ Create an autocomplete view
 ===========================
 
 - Example source: `test_project/alight_foreign_key
-  <https://github.com/yourlabs/django-autocomplete-light/blob/alight-backend/test_project/alight_foreign_key/urls.py>`_
+  <https://github.com/yourlabs/django-autocomplete-light/blob/master/test_project/alight_foreign_key/urls.py>`_
 - Live demo: `/alight_foreign_key/test-autocomplete/?q=test
   <http://localhost:8000/alight_foreign_key/test-autocomplete/?q=test>`_
 
@@ -162,7 +162,7 @@ Automation with djhacker
 ------------------------
 
 - Example source: `test_project/alight_djhacker_formfield
-  <https://github.com/yourlabs/django-autocomplete-light/blob/alight-backend/test_project/alight_djhacker_formfield/urls.py>`_
+  <https://github.com/yourlabs/django-autocomplete-light/blob/master/test_project/alight_djhacker_formfield/urls.py>`_
 - Live demo: `/admin/alight_djhacker_formfield/tmodel/add/
   <http://localhost:8000/admin/alight_djhacker_formfield/tmodel/add/>`_
 
@@ -207,7 +207,7 @@ Using autocompletes outside the admin
 =====================================
 
 - Example source: `test_project/alight_outside_admin
-  <https://github.com/yourlabs/django-autocomplete-light/tree/alight-backend/test_project/alight_outside_admin>`_
+  <https://github.com/yourlabs/django-autocomplete-light/tree/master/test_project/alight_outside_admin>`_
 - Live demo: `/alight_outside_admin/
   <http://localhost:8000/alight_outside_admin/>`_
 
@@ -220,7 +220,7 @@ Creation of new choices
 =======================
 
 - Example source: `test_project/alight_one_to_one
-  <https://github.com/yourlabs/django-autocomplete-light/blob/alight-backend/test_project/alight_one_to_one/urls.py>`_
+  <https://github.com/yourlabs/django-autocomplete-light/blob/master/test_project/alight_one_to_one/urls.py>`_
 - Live demo: `/admin/alight_one_to_one/tmodel/add/
   <http://localhost:8000/admin/alight_one_to_one/tmodel/add/>`_
 
@@ -254,7 +254,7 @@ Autocompleting from a list of strings
 ======================================
 
 - Example source: `test_project/alight_list
-  <https://github.com/yourlabs/django-autocomplete-light/tree/alight-backend/test_project/alight_list>`_
+  <https://github.com/yourlabs/django-autocomplete-light/tree/master/test_project/alight_list>`_
 
 Use :py:class:`~dal_alight.views.AlightListView` when results come from a
 plain Python list rather than a QuerySet:
@@ -354,7 +354,7 @@ django-taggit integration
 -------------------------
 
 - Example source: `test_project/alight_taggit
-  <https://github.com/yourlabs/django-autocomplete-light/tree/alight-backend/test_project/alight_taggit>`_
+  <https://github.com/yourlabs/django-autocomplete-light/tree/master/test_project/alight_taggit>`_
 - Live demo: `/admin/alight_taggit/tmodel/add/
   <http://localhost:8000/admin/alight_taggit/tmodel/add/>`_
 
@@ -395,7 +395,7 @@ Generic Foreign Key support
 ===========================
 
 - Example source: `test_project/alight_generic_foreign_key
-  <https://github.com/yourlabs/django-autocomplete-light/tree/alight-backend/test_project/alight_generic_foreign_key>`_
+  <https://github.com/yourlabs/django-autocomplete-light/tree/master/test_project/alight_generic_foreign_key>`_
 - Live demo: `/admin/alight_generic_foreign_key/tmodel/add/
   <http://localhost:8000/admin/alight_generic_foreign_key/tmodel/add/>`_
 


### PR DESCRIPTION
## Summary

- 8 GitHub source links in `docs/alight.rst` and `docs/_forward.rst` pointed to the old `alight-backend` branch
- All test project directories referenced (`alight_foreign_key`, `alight_djhacker_formfield`, `alight_outside_admin`, `alight_one_to_one`, `alight_list`, `alight_taggit`, `alight_generic_foreign_key`, `alight_linked_data`) exist on `master`
- Updated all links from `.../blob/alight-backend/...` / `.../tree/alight-backend/...` to `master`

## Test plan

- [ ] Verify the 8 updated links resolve correctly on GitHub after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example source links throughout documentation to reference corrected repository paths, ensuring users can access the appropriate example code.
  * Improved consistency of GitHub link formats across multiple demonstration sections covering foreign key relationships, admin customizations, one-to-one relationships, list displays, tagging functionality, and generic foreign key implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yourlabs/django-autocomplete-light/pull/1415?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->