### PR TITLE
release: 4.0.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -81,6 +81,10 @@
 4.0.1
 
     Fixes
+    - #1417        ModelSelect2(Multiple) without a URL now renders the full
+                   queryset again (regression: Select2InitialRenderMixin
+                   unconditionally narrowed choices to selected PKs at render
+                   time, breaking non-AJAX edit forms)
     - #1333        WidgetMixin.forward list is now copied on __init__ and
                    __deepcopy__, preventing silent mutation across form
                    subclasses that share a base class widget instance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-autocomplete-light"
-version = "4.0.0"
+version = "4.0.1"
 description = "Fresh autocompletes for Django"
 readme = {file = "README", content-type = "text/x-rst"}
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

- Bumps version to **4.0.1** in `pyproject.toml`
- Adds #1417 to the `4.0.1` CHANGELOG entry

## Context

#1417 reports a regression in 4.0.0 where `ModelSelect2(Multiple)` without an AJAX URL only renders already-selected choices on edit forms. The root cause was `Select2InitialRenderMixin.render()` (added in 9eabac0c) unconditionally filtering `choices.queryset` to `pk__in=selected_pks` at render time, regardless of whether a URL was configured. This was already fixed in master by 12efd270 (removed the mixin entirely). The fix just needs to ship as a patch release.

The 4.0.1 CHANGELOG stub already existed (for #1333); this PR adds the #1417 entry and bumps the version so a PyPI release can be cut.

## Test plan

- [ ] Confirm `python -m build` produces a `4.0.1` wheel/sdist
- [ ] Verify `ModelSelect2Multiple(url=None)` on an edit form shows the full queryset
- [ ] Publish to PyPI and close #1417

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a regression in ModelSelect2(Multiple) widgets that was introduced in the previous release. Widgets without a configured URL now correctly display the complete queryset when initially rendering on the page, instead of limiting available choices to only those specific items that were previously selected by the user in their prior interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yourlabs/django-autocomplete-light/pull/1418?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->