### PR TITLE
Fix double-define

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        include:
+          - python-version: "3.11"
+            django-version: "5.2"
+            tox-env: py311-dj52
+          - python-version: "3.12"
+            django-version: "5.2"
+            tox-env: py312-dj52
+          - python-version: "3.13"
+            django-version: "5.2"
+            tox-env: py313-dj52
+          - python-version: "3.14"
+            django-version: "5.2"
+            tox-env: py314-dj52
+          - python-version: "3.14"
+            django-version: "6.0"
+            tox-env: py314-dj60
+    name: Python ${{ matrix.python-version }} / Django ${{ matrix.django-version }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -40,8 +56,8 @@ jobs:
           allow-prereleases: true
       - name: Install Firefox
         uses: browser-actions/setup-firefox@v1
-      - run: pip install tox tox-gh-actions
-      - run: tox
+      - run: pip install tox
+      - run: tox -e ${{ matrix.tox-env }}
         env:
           MOZ_HEADLESS: "1"
           BROWSER: firefox

--- a/README
+++ b/README
@@ -9,6 +9,10 @@ Features
 --------
 
 - **Python 3.11–3.14 and Django 5.2–6.0+ support**
+- **Django 6.0+ recommended** for ``dal_alight``: widget media uses
+  ``type="module"`` scripts so merged form media does not double-execute
+  web component registration.  On Django 5.2, ``dal_alight`` falls back to
+  classic script tags.
 - Django (multiple) choice support,
 - Django (multiple) model choice support,
 - Django generic foreign key support (through django-querysetsequence),

--- a/docs/upgrade_from_v4_to_v5.rst
+++ b/docs/upgrade_from_v4_to_v5.rst
@@ -172,7 +172,7 @@ If you override ``templateResult`` or ``templateSelection``, handle
 items.
 
 Migrating custom JavaScript from Select2 to alight
--------------------------------------------------
+--------------------------------------------------
 
 The new ``dal_alight`` backend does not use jQuery or Select2.  It uses native
 web components plus ``dal-django.js``.

--- a/src/dal_alight/widgets.py
+++ b/src/dal_alight/widgets.py
@@ -1,3 +1,4 @@
+import django
 from django import forms
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
@@ -31,9 +32,25 @@ class AlightWidgetMixin:
 
     @property
     def media(self):
+        # Django 6+ forms.Media supports Script(type="module"), which ensures
+        # each URL executes once when multiple widgets merge media
+        # (customElements.define must not run twice).  On older Django versions
+        # we fall back to plain script paths.
+        if django.VERSION >= (6, 0):
+            from django.forms.widgets import Script
+
+            js = [
+                Script('dal_alight/autocomplete-light.js', type='module'),
+                Script('dal_alight/dal-django.js', type='module'),
+            ]
+        else:
+            js = [
+                'dal_alight/autocomplete-light.js',
+                'dal_alight/dal-django.js',
+            ]
         return forms.Media(
             css=dict(all=['dal_alight/autocomplete-light.css']),
-            js=['dal_alight/autocomplete-light.js', 'dal_alight/dal-django.js'],
+            js=js,
         )
 
     def render(self, name, value, attrs=None, renderer=None, **kwargs):

--- a/test_project/alight_foreign_key/test_units.py
+++ b/test_project/alight_foreign_key/test_units.py
@@ -270,6 +270,16 @@ class AlightWidgetMixinMediaTest(TestCase):
         media_css = str(w.media)
         self.assertIn('autocomplete-light.css', media_css)
 
+    def test_media_uses_module_scripts_on_django_6(self):
+        import django
+
+        w = ModelAlight(url='x')
+        media_js = str(w.media)
+        if django.VERSION >= (6, 0):
+            self.assertIn('type="module"', media_js)
+        else:
+            self.assertNotIn('type="module"', media_js)
+
 
 class ModelAlightRenderTest(TestCase):
     def setUp(self):

--- a/test_project/templates/admin/base_site.html
+++ b/test_project/templates/admin/base_site.html
@@ -32,7 +32,7 @@ document.addEventListener('autocompleteChoiceSelected', function(ev) {
 {% block extrahead %}
 {{ block.super }}
 <link rel="stylesheet" href="{% static 'dal_alight/autocomplete-light.css' %}">
-<script src="{% static 'dal_alight/autocomplete-light.js' %}"></script>
+<script type="module" src="{% static 'dal_alight/autocomplete-light.js' %}"></script>
 <style>
 /* push user-tools to the end so the search bar can sit in the middle */
 #user-tools { order: 3; }

--- a/tox.ini
+++ b/tox.ini
@@ -52,6 +52,9 @@ python =
     3.12: py312
     3.13: py313
     3.14: py314
+django =
+    5.2: dj52
+    6.0: dj60
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated widget media output so merged scripts load as ES modules (`type="module"`) on Django 6+, while Django 5.2 continues using classic script tags.
  * Switched autocomplete-light JavaScript loading to module script mode for consistent browser execution.
* **Tests**
  * Added a unit test verifying the widget media output changes correctly by Django version.
* **Documentation**
  * Updated the README to recommend Django 6.0+ for merged form media behavior; minor upgrade guide formatting adjustment.
* **Chores**
  * Refined CI/tox matrices to run targeted Python/Django combinations via selected tox environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->