### PR TITLE
BC BREAKS and changes in 5.1-dev (soon available with --pre)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - run: pip install tox
       - run: tox -e docs
 
-  tests:
+  unit-tests:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -47,7 +47,38 @@ jobs:
           - python-version: "3.14"
             django-version: "6.0"
             tox-env: py314-dj60
-    name: Python ${{ matrix.python-version }} / Django ${{ matrix.django-version }}
+    name: unit / Python ${{ matrix.python-version }} / Django ${{ matrix.django-version }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+      - run: pip install tox
+      - run: tox -e ${{ matrix.tox-env }} -- --ignore-glob='**/test_functional.py'
+
+  browser-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python-version: "3.11"
+            django-version: "5.2"
+            tox-env: py311-dj52
+          - python-version: "3.12"
+            django-version: "5.2"
+            tox-env: py312-dj52
+          - python-version: "3.13"
+            django-version: "5.2"
+            tox-env: py313-dj52
+          - python-version: "3.14"
+            django-version: "5.2"
+            tox-env: py314-dj52
+          - python-version: "3.14"
+            django-version: "6.0"
+            tox-env: py314-dj60
+    name: browser / Python ${{ matrix.python-version }} / Django ${{ matrix.django-version }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -57,7 +88,7 @@ jobs:
       - name: Install Firefox
         uses: browser-actions/setup-firefox@v1
       - run: pip install tox
-      - run: tox -e ${{ matrix.tox-env }}
+      - run: tox -e ${{ matrix.tox-env }} -- --ignore-glob='**/test_units.py' --ignore-glob='**/test_views.py' --ignore-glob='**/test_forms.py'
         env:
           MOZ_HEADLESS: "1"
           BROWSER: firefox

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,10 @@
 5.1.0
 
-    BC BREAK: whatever hack you had to implement to design the text input for
-    the alight web component: you can now set the widget attrs directly.
+    BC BREAKS:
+    - whatever hack you had to implement to design the text input for the
+      alight web component: you can now set the widget attrs directly.
+    - no more non-URL alight widget support, just use plain
+      select/radio/checkboxes which your UI should support already
 
     Changed
     - dal_alight: Django widget attrs (``id``, classes, etc.) are rendered

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,50 @@
+5.1.0
+
+    BC BREAK: whatever hack you had to implement to design the text input for
+    the alight web component: you can now set the widget attrs directly.
+
+    Changed
+    - dal_alight: Django widget attrs (``id``, classes, etc.) are rendered
+      on the visible search ``<input>`` instead of a hidden ``<select>``.
+      The search field is the only part of the widget that needs theming;
+      ``<label for="…">`` and admin field identity follow the input as
+      usual.
+
+    - dal_alight: selected values are submitted via ``<input type="hidden"
+      slot="values">`` (and deck chips) instead of a hidden
+      ``<select slot="select">``.  This removed a large amount of
+      option-sync logic from the JS.
+
+    - dal_alight: ``ListAlight`` now requires a ``url``.  Client-side
+      local filtering of ``<option>`` elements was removed to keep the JS
+      small.  For a static choice list without a server round-trip, use a
+      normal ``<select>`` in your UI — as long as select and text-input
+      styling match your theme, the experience stays consistent.
+
+    - dal_alight: removed ``Alight`` and ``AlightMultiple`` widgets.
+      They were redundant with ``ListAlight`` (single) and
+      ``ModelAlightMultiple`` / ``TagAlight`` (multi) after client-side
+      filtering was dropped.  Migrate ``Alight`` → ``ListAlight`` with
+      ``AlightListView``.
+
+    - dal.test.stories: backend-specific Selenium story classes moved to
+      ``dal_alight.test`` and ``dal_select2.test``. Shared stories raise
+      ``NotImplementedError`` for value assertions; functional tests
+      import the appropriate backend subclass.
+
+    Improvements
+    - dal_alight: widgets extend ``forms.TextInput`` (via
+      ``AlightChoiceMixin`` for choice/deck plumbing) instead of
+      ``forms.Select*``.  Standard widget ``attrs`` — merged with
+      ``build_attrs()`` — configure the visible search input.
+
+    - dal.widgets: ``data-autocomplete-light-url`` and
+      ``data-autocomplete-light-function`` moved from shared ``WidgetMixin`` to
+      ``dal_select2.widgets.Select2WidgetMixin`` (Select2-only).
+
+    - test_project: tests run in parallel via ``pytest-xdist`` (``-n auto``);
+      CI splits unit and browser suites into separate workflow jobs.
+
 5.0.0
 
     WARNING: BC break identified with DAL v4, in the process of resolution
@@ -20,7 +67,6 @@
 
               Widgets (dal_alight.widgets):
               - ModelAlight, ModelAlightMultiple   (QuerySet-backed)
-              - Alight, AlightMultiple             (arbitrary choices)
               - ListAlight                         (paired with AlightListView)
               - TagAlight                          (free-text comma tags)
               - TaggitAlight                       (django-taggit bridge)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ Forwarding: `forward=['country']` on the widget → `self.forwarded.get('country
 ## Tests
 ```bash
 cd test_project/
-pytest -v --liveserver 127.0.0.1:9999
-BROWSER=firefox MOZ_HEADLESS=1 pytest -v   # headless
+tox -e py314-dj52 -- --ignore-glob='**/test_functional.py'           # unit (-n auto)
+tox -e py314-dj52 -- --ignore-glob='**/test_units.py' --ignore-glob='**/test_views.py' --ignore-glob='**/test_forms.py'  # browser (-n auto)
+BROWSER=firefox tox -e py314-dj52 -- --ignore-glob='**/test_units.py' --ignore-glob='**/test_views.py' --ignore-glob='**/test_forms.py' --splinter-headless
 ```

--- a/README
+++ b/README
@@ -9,10 +9,10 @@ Features
 --------
 
 - **Python 3.11–3.14 and Django 5.2–6.0+ support**
-- **Django 6.0+ recommended** for ``dal_alight``: widget media uses
-  ``type="module"`` scripts so merged form media does not double-execute
-  web component registration.  On Django 5.2, ``dal_alight`` falls back to
-  classic script tags.
+- **``dal_alight`` widget media uses ``type="module"`` scripts** on Django
+  5.2+ (via ``django.forms.widgets.Script`` or a small backport in
+  ``dal_alight.media``) so merged form media does not double-execute web
+  component registration.
 - Django (multiple) choice support,
 - Django (multiple) model choice support,
 - Django generic foreign key support (through django-querysetsequence),

--- a/docs/alight.rst
+++ b/docs/alight.rst
@@ -138,6 +138,26 @@ Use :py:class:`~dal_alight.widgets.ModelAlight` for a ``ForeignKey`` field:
                 'birth_country': autocomplete.ModelAlight(url='country-autocomplete')
             }
 
+Customizing the search input
+----------------------------
+
+Alight widgets extend django.forms.widgets.TextInput — the visible
+search field is a regular text input.  Configure it with the
+usual widget ``attrs`` (``class``, ``placeholder``, ``aria-label``, …)::
+
+    widgets = {
+        'birth_country': autocomplete.ModelAlight(
+            url='country-autocomplete',
+            attrs={
+                'class': 'form-control',
+                'placeholder': 'Search countries…',
+            },
+        ),
+    }
+
+Selected values are stored in hidden inputs inside the
+``<autocomplete-select>`` component, not in the search field itself.
+
 ManyToManyField (multi select)
 ------------------------------
 
@@ -154,8 +174,8 @@ Initial values on edit forms
 ----------------------------
 
 :py:class:`~dal_alight.widgets.ModelAlight` and
-:py:class:`~dal_alight.widgets.ModelAlightMultiple` inject the currently
-selected object(s) into the ``<select>`` options at render time so they
+:py:class:`~dal_alight.widgets.ModelAlightMultiple` render the currently
+selected object(s) as hidden inputs and deck chips at render time so they
 appear pre-selected without an extra AJAX call.
 
 Automation with djhacker
@@ -475,12 +495,8 @@ Class reference
      - Single select, QuerySet-backed (ForeignKey)
    * - :py:class:`~dal_alight.widgets.ModelAlightMultiple`
      - Multi select, QuerySet-backed (ManyToManyField)
-   * - :py:class:`~dal_alight.widgets.Alight`
-     - Single select, arbitrary choices
-   * - :py:class:`~dal_alight.widgets.AlightMultiple`
-     - Multi select, arbitrary choices
    * - :py:class:`~dal_alight.widgets.ListAlight`
-     - Single select, list-backed
+     - Single select, list-backed (requires ``url``)
    * - :py:class:`~dal_alight.widgets.TagAlight`
      - Free-text tag widget (comma-separated)
    * - :py:class:`~dal_alight.widgets.TaggitAlight`

--- a/docs/frontends.rst
+++ b/docs/frontends.rst
@@ -94,10 +94,9 @@ Feature matrix
      - yes
      - alight uses × buttons in the deck
    * - Client-side local filtering
-     - yes
      - **no**
-     - alight: ``Alight`` / ``AlightMultiple`` without a ``url`` filter ``<option>``
-       elements locally — no server round-trip
+     - yes
+     - alight choice widgets require a ``url``; values are submitted via hidden inputs
    * - Max-choices cap with auto-eviction
      - yes
      - **no**
@@ -130,8 +129,6 @@ When to use ``dal_alight``
 - No jQuery in the stack (modern frontend, HTMX, API-only server-side, etc.).
 - Minimising JS payload and eliminating third-party dependencies is a priority.
 - You want ``max-choices`` enforcement client-side without extra code.
-- Some fields use a small static choice list and local filtering avoids an unnecessary
-  server round-trip.
 - You prefer the server to own result rendering (HTML fragments) rather than templating
   in JS — useful when labels contain Django template logic or server-side permissions.
 - You are building a web-component or shadow-DOM ecosystem and need a widget that fits
@@ -198,12 +195,6 @@ Class name mapping
    * - :py:class:`~dal_alight.widgets.ModelAlightMultiple`
      - :py:class:`~dal_select2.widgets.ModelSelect2Multiple`
      - Widget — M2M
-   * - :py:class:`~dal_alight.widgets.Alight`
-     - :py:class:`~dal_select2.widgets.Select2`
-     - Widget — arbitrary choices, single
-   * - :py:class:`~dal_alight.widgets.AlightMultiple`
-     - :py:class:`~dal_select2.widgets.Select2Multiple`
-     - Widget — arbitrary choices, multiple
    * - :py:class:`~dal_alight.widgets.ListAlight`
      - :py:class:`~dal_select2.widgets.ListSelect2`
      - Widget — list-backed

--- a/docs/upgrade_from_select2_to_alight.rst
+++ b/docs/upgrade_from_select2_to_alight.rst
@@ -43,9 +43,9 @@ form fields.
    * - :py:class:`~dal_select2.widgets.ModelSelect2Multiple`
      - :py:class:`~dal_alight.widgets.ModelAlightMultiple`
    * - :py:class:`~dal_select2.widgets.Select2`
-     - :py:class:`~dal_alight.widgets.Alight`
+     - :py:class:`~dal_alight.widgets.ListAlight`
    * - :py:class:`~dal_select2.widgets.Select2Multiple`
-     - :py:class:`~dal_alight.widgets.AlightMultiple`
+     - :py:class:`~dal_alight.widgets.ModelAlightMultiple` or :py:class:`~dal_alight.widgets.TagAlight`
    * - :py:class:`~dal_select2.widgets.ListSelect2`
      - :py:class:`~dal_alight.widgets.ListAlight`
    * - :py:class:`~dal_select2.widgets.TagSelect2`
@@ -79,3 +79,18 @@ Behavioural differences
 - **Forwarding**: the ``forward`` widget argument and :py:mod:`dal.forward` helpers work identically.
 - **Admin registration**: ``ModelAdmin.form`` assignment works identically.
 - **Static files**: replace ``dal_select2`` media with ``dal_alight`` media; jQuery is no longer loaded by the widget.
+
+Changes in 5.1
+==============
+
+Since 5.1.0 (see ``CHANGELOG``):
+
+- Widget ``attrs`` apply to the visible search ``<input>``, not a hidden
+  ``<select>``.
+- ``ListAlight`` now requires a ``url``; client-side local filtering of static
+  ``choices`` was removed.  Use ``ListAlight`` with ``AlightListView``, or a
+  plain ``<select>`` for tiny static lists.
+- The ``change`` event fires on ``<autocomplete-select>``, not a ``<select>``.
+- ``Alight`` and ``AlightMultiple`` were removed; use the widget mapping table
+  above (``Select2`` → ``ListAlight``; ``Select2Multiple`` →
+  ``ModelAlightMultiple`` or ``TagAlight``).

--- a/docs/upgrade_from_v4_to_v5.rst
+++ b/docs/upgrade_from_v4_to_v5.rst
@@ -205,8 +205,6 @@ Select2 convenience import style.
 
 - ``ModelAlight``
 - ``ModelAlightMultiple``
-- ``Alight``
-- ``AlightMultiple``
 - ``ListAlight``
 - ``TagAlight``
 - ``TaggitAlight``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-autocomplete-light"
-version = "5.0.0"
+version = "5.1.0"
 description = "Fresh autocompletes for Django"
 readme = {file = "README", content-type = "text/x-rst"}
 license = {text = "MIT"}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --nomigrations --create-db --reuse-db
+addopts = -n auto --nomigrations --create-db --reuse-db
 DJANGO_SETTINGS_MODULE=settings.base
 django_debug_mode=true
 filterwarnings =

--- a/src/dal/autocomplete.py
+++ b/src/dal/autocomplete.py
@@ -33,8 +33,6 @@ def _installed(*apps):
 
 if _installed('dal_alight'):
     from dal_alight.widgets import (
-        Alight,
-        AlightMultiple,
         ListAlight,
         ModelAlight,
         ModelAlightMultiple,

--- a/src/dal/test/stories.py
+++ b/src/dal/test/stories.py
@@ -94,11 +94,14 @@ class BaseStory(object):
         assert text == self.get_label()
 
     def get_value(self):
-        """Return the autocomplete field value."""
-        field = self.case.browser.find_by_css(
-            self.field_selector)
+        """Return the autocomplete field value.
 
-        return field['value']
+        Backend-specific story subclasses in ``dal_select2.test`` and
+        ``dal_alight.test`` must override this.
+        """
+        raise NotImplementedError(
+            'Use Select2SelectOption or AlightSelectOption.'
+        )
 
     @tenacity.retry(stop=tenacity.stop_after_delay(3))
     def assert_value(self, value):
@@ -225,13 +228,13 @@ class SelectOption(BaseStory):
         self.case.click(self.field_clear_selector)
 
 
-class InlineSelectOption(SelectOption):
-    """Same as UserCanSelectOption, in a given inline."""
+class InlineSelectOptionMixin:
+    """Shared inline formset setup for autocomplete stories."""
 
     def __init__(self, case, inline_number, inline_related_name=None,
                  **kwargs):
         """
-        Do the same as UserCanSelectOption, in inline inline_number.
+        Do the same as SelectOption, in inline inline_number.
 
         Where inline_related_name should be the related_name option for the
         foreign key used for the InlineModelAdmin.
@@ -250,15 +253,15 @@ class InlineSelectOption(SelectOption):
             self.field_name
         )
 
-        # Scope input_selector to the inline container when the widget
-        # embeds its text input inside the field (e.g. alight), rather than
-        # in a global dropdown (e.g. select2 whose .select2-search__field
-        # lives outside the field container).
-        if getattr(case, 'input_in_field_container', False):
-            self.input_selector = '%s %s' % (
-                self.field_container_selector, self.input_selector)
+        self._scope_inline_input_selector()
+        self._ensure_inline_visible()
 
-        # Ensure the inline is displayed else click to add it
+    def _scope_inline_input_selector(self):
+        """Override in backend-specific inline story subclasses."""
+        raise NotImplementedError
+
+    def _ensure_inline_visible(self):
+        """Ensure enough inline rows exist and widgets are ready."""
         add = self.case.browser.links.find_by_partial_text('Add another').first
 
         num = len(
@@ -268,21 +271,24 @@ class InlineSelectOption(SelectOption):
         )
         while num < self.inline_number + 1:
             add.click()
-
-            # Did it work or wasn't the js loaded yet ?
-            try:
-                self.case.browser.find_by_css(
-                    self.field_selector.replace(
-                        str(self.inline_number),
-                        str(num),
-                    )
-                ).first  # as usual, rely on implicit wait
-            except Exception:
-                continue
+            expected_selector = self.field_selector.replace(
+                str(self.inline_number),
+                str(num),
+            )
+            deadline = time.time() + 5
+            while time.time() < deadline:
+                try:
+                    self.case.browser.find_by_css(expected_selector).first
+                    break
+                except Exception:
+                    time.sleep(0.1)
+            else:
+                raise AssertionError(
+                    'Inline field %s did not appear after clicking "Add another".'
+                    % expected_selector
+                )
 
             num += 1
-            # Wait for any newly-connected web components (e.g. alight) to
-            # finish their connectedCallback before the next interaction.
             if hasattr(self.case, 'wait_script'):
                 self.case.wait_script()
 
@@ -328,40 +334,6 @@ class CreateOption(SelectOption):
         self.case.enter_text(self.input_selector, name)
 
 
-class AlightCreateOption(CreateOption):
-    """Create an option on the fly — alight backend."""
-
-    def create_option(self, name):
-        create_sel = self.case.get_create_option_selector(name)
-        self._open_and_type(name)
-        self.case.browser.is_element_present_by_css(create_sel)
-        initial_count = self.case.browser.evaluate_script(
-            'document.querySelectorAll("%s option").length' % self.field_selector
-        )
-        self.case.js_click(create_sel)
-        deadline = time.time() + 5
-        while time.time() < deadline:
-            count = self.case.browser.evaluate_script(
-                'document.querySelectorAll("%s option").length'
-                % self.field_selector
-            )
-            if count > initial_count:
-                break
-            time.sleep(0.1)
-
-
-class Select2CreateOption(CreateOption):
-    """Create an option on the fly — select2 backend."""
-
-    def create_option(self, name):
-        self._open_and_type(name)
-        self.case.browser.is_element_present_by_text(name)
-        self.case.click(self.option_selector)
-        self.case.browser.is_element_not_present_by_css(
-            '.select2-results__options'
-        )
-
-
 class MultipleMixin(object):
     """Enable multiple choice support with stories."""
 
@@ -393,15 +365,14 @@ class MultipleMixin(object):
         ]
 
     def get_values(self):
-        """Return the autocomplete field value."""
-        script = """
-        window.GET_VALUES = [];
-        document.querySelectorAll("%s option:checked").forEach(function(opt) {
-            GET_VALUES.push(opt.value);
-        });
-        """ % self.field_selector
-        self.case.browser.execute_script(script)
-        return self.case.browser.evaluate_script('window.GET_VALUES')
+        """Return the autocomplete field values.
+
+        Backend-specific story subclasses in ``dal_select2.test`` and
+        ``dal_alight.test`` must override this.
+        """
+        raise NotImplementedError(
+            'Use Select2SelectOptionMultiple or AlightSelectOptionMultiple.'
+        )
 
     def assert_labels(self, texts):
         """Assert that all labels match texts."""
@@ -438,39 +409,4 @@ class MultipleMixin(object):
         self.assert_values(values)
 
 
-class CreateOptionMultiple(MultipleMixin, CreateOption):
-    """Multiple version of CreateOptions."""
 
-
-class AlightCreateOptionMultiple(MultipleMixin, AlightCreateOption):
-    """Multiple-select variant of AlightCreateOption."""
-
-
-class Select2CreateOptionMultiple(MultipleMixin, Select2CreateOption):
-    """Multiple-select variant of Select2CreateOption."""
-
-
-class SelectOptionMultiple(MultipleMixin, SelectOption):
-    """Multiple version of CreateOptions."""
-
-
-class InlineSelectOptionMultiple(MultipleMixin, InlineSelectOption):
-    """Multiple options for InlineSelectOption."""
-
-    def __init__(self, case, inline_number, inline_related_name=None,
-                 **kwargs):
-        """Set input_selector with field_container_selector."""
-        super().__init__(
-            case,
-            inline_number,
-            inline_related_name=inline_related_name,
-            **kwargs
-        )
-
-        # InlineSelectOption already scoped input_selector when
-        # input_in_field_container is True; avoid scoping it a second time.
-        if not getattr(case, 'input_in_field_container', False):
-            self.input_selector = '%s %s' % (
-                self.field_container_selector,
-                self.input_selector,
-            )

--- a/src/dal/widgets.py
+++ b/src/dal/widgets.py
@@ -52,19 +52,6 @@ class WidgetMixin(object):
         clone.forward = self.forward.copy()
         return clone
 
-    def build_attrs(self, *args, **kwargs):
-        """Build HTML attributes for the widget."""
-        attrs = super(WidgetMixin, self).build_attrs(*args, **kwargs)
-
-        if self.url is not None:
-            attrs['data-autocomplete-light-url'] = self.url
-
-        autocomplete_function = getattr(self, 'autocomplete_function', None)
-        if autocomplete_function:
-            attrs.setdefault('data-autocomplete-light-function',
-                             autocomplete_function)
-        return attrs
-
     def filter_choices_to_render(self, selected_choices):
         """Filter choices to selected ones; inject values absent from the list."""
         existing_keys = {str(c[0]) for c in self.choices}

--- a/src/dal_alight/media.py
+++ b/src/dal_alight/media.py
@@ -1,0 +1,80 @@
+"""Media helpers for dal_alight module scripts.
+
+Django 5.2+ ships :class:`django.forms.widgets.Script` for ``type="module"``
+script tags.  Older Django versions lack that class but
+:meth:`django.forms.Media.render_js` still honours objects with ``__html__``
+since 5.1.  We backport ``Script`` here so widget media always renders ES
+module scripts on every supported Django version without a second classic
+``<script>`` execution (which would re-run ``customElements.define``).
+"""
+
+from django import forms
+from django.forms.utils import flatatt
+from django.templatetags.static import static
+from django.utils.html import format_html, html_safe
+
+
+@html_safe
+class MediaAsset:
+    """Backport of ``django.forms.widgets.MediaAsset`` (Django 5.2+)."""
+
+    element_template = '{path}'
+
+    def __init__(self, path, **attributes):
+        self._path = path
+        self.attributes = attributes
+
+    def __eq__(self, other):
+        return (
+            (self.__class__ is other.__class__ and self.path == other.path)
+            or (isinstance(other, str) and self._path == other)
+        )
+
+    def __hash__(self):
+        return hash(self._path)
+
+    def __str__(self):
+        return format_html(
+            self.element_template,
+            path=self.path,
+            attributes=flatatt(self.attributes),
+        )
+
+    def __repr__(self):
+        return f'{type(self).__qualname__}({self._path!r})'
+
+    @property
+    def path(self):
+        if self._path.startswith(('http://', 'https://', '/')):
+            return self._path
+        return static(self._path)
+
+
+class Script(MediaAsset):
+    """Backport of ``django.forms.widgets.Script`` (Django 5.2+)."""
+
+    element_template = '<script src="{path}"{attributes}></script>'
+
+    def __init__(self, src, **attributes):
+        super().__init__(src, **attributes)
+
+
+def get_script_class():
+    """Return Django's Script when available, else our backport."""
+    try:
+        from django.forms.widgets import Script as DjangoScript
+    except ImportError:
+        return Script
+    return DjangoScript
+
+
+def alight_media():
+    """Widget media: CSS + ES module JS for autocomplete-light."""
+    script = get_script_class()
+    return forms.Media(
+        css=dict(all=['dal_alight/autocomplete-light.css']),
+        js=[
+            script('dal_alight/autocomplete-light.js', type='module'),
+            script('dal_alight/dal-django.js', type='module'),
+        ],
+    )

--- a/src/dal_alight/static/dal_alight/autocomplete-light.css
+++ b/src/dal_alight/static/dal_alight/autocomplete-light.css
@@ -64,19 +64,6 @@ html[data-theme="light"] {
   background-color: var(--autocomplete-light-highlight-bg);
 }
 
-autocomplete-select select {
-  border: 0 !important;
-  clip: rect(0 0 0 0) !important;
-  -webkit-clip-path: inset(50%) !important;
-  clip-path: inset(50%) !important;
-  height: 1px !important;
-  overflow: hidden !important;
-  padding: 0 !important;
-  position: absolute !important;
-  width: 1px !important;
-  white-space: nowrap !important;
-}
-
 autocomplete-select [slot=deck] {
   display: block;
 }

--- a/src/dal_alight/static/dal_alight/autocomplete-light.js
+++ b/src/dal_alight/static/dal_alight/autocomplete-light.js
@@ -297,25 +297,26 @@ class AutocompleteLight extends HTMLElement {
 class AutocompleteSelectInput extends AutocompleteLight {
   get url() {
     if (!this.getAttribute('url')) return
-    var url = this.getAttribute('url') + '?q=' + this.input.value
-    this.parentNode.querySelectorAll('option[selected]').forEach((option) => {
-      url += '&_=' + option.value
-    })
+    var url = this.getAttribute('url') + '?q=' + encodeURIComponent(this.input.value)
+    var parent = this.closest('autocomplete-select')
+    if (parent) {
+      parent.valueInputs.forEach((input) => {
+        url += '&_=' + encodeURIComponent(input.value)
+      })
+    }
     var buildFwd = window.AutocompleteLightBuildForward
-    if (buildFwd) {
-      var parent = this.closest('autocomplete-select')
-      if (parent) {
-        var fwd = buildFwd(parent)
-        if (fwd) url += '&forward=' + encodeURIComponent(fwd)
-      }
+    if (buildFwd && parent) {
+      var fwd = buildFwd(parent)
+      if (fwd) url += '&forward=' + encodeURIComponent(fwd)
     }
     return url
   }
 
   receive(ev) {
     if (ev.target.status && !(ev.target.status >= 200 && ev.target.status < 300)) return
+    const parent = this.closest('autocomplete-select')
     const selectedValues = new Set(
-      Array.from(this.parentNode.querySelectorAll('option[selected]')).map(o => o.value)
+      parent ? Array.from(parent.valueInputs).map((input) => input.value) : []
     )
     if (selectedValues.size) {
       const tmp = document.createElement('div')
@@ -332,19 +333,6 @@ class AutocompleteSelectInput extends AutocompleteLight {
     if (this.url) {
       return super.download()
     }
-
-    // No URL: filter local <option> tags instead of fetching from server.
-    this.receive({
-      target: {
-        response: Array.from(
-          this.closest('autocomplete-select').select.options
-        ).filter(
-          (item) => !item.selected && item.innerText.startsWith(this.input.value)
-        ).map(
-          (item) => `<div data-value="${item.getAttribute('value')}">${item.innerHTML}</div>`
-        ).join('\n'),
-      }
-    })
   }
 }
 
@@ -353,7 +341,7 @@ class AutocompleteSelect extends HTMLElement {
   maxChoices = 0
 
   connectedCallback(retries = 20) {
-    if (!this.select || !this.input.input) {
+    if (!this.deck || !this.input || !this.input.input) {
       // Strip data-bound while waiting for children — it may have been
       // inherited from a cloneNode(true), which would make wait_script()
       // return too early before full init completes in the retry.
@@ -374,7 +362,7 @@ class AutocompleteSelect extends HTMLElement {
     const attrMax = parseInt(this.getAttribute('max-choices'))
     this.maxChoices = isNaN(attrMax) ? 0 : attrMax
 
-    if (!this.select.multiple) {
+    if (!this.multiple) {
       this.maxChoices = 1
     }
 
@@ -388,27 +376,27 @@ class AutocompleteSelect extends HTMLElement {
     this.setAttribute('data-bound', 'true')
   }
 
+  findDeckItem(value) {
+    return Array.from(this.deck.querySelectorAll('[data-value]'))
+      .find((el) => el.getAttribute('data-value') === value) || null
+  }
+
   reconcileState() {
-    // ensure all selected options are in deck
-    Array.from(
-      this.select.querySelectorAll('option[selected]')
-    ).forEach((option) => {
-      var exists = this.deck.querySelectorAll(
-        '[data-value="' + option.getAttribute('value') + '"]'
-      )
-      if (exists.length) return
+    // ensure all hidden value inputs are in deck
+    Array.from(this.valueInputs).forEach((input) => {
+      var value = input.value
+      if (this.findDeckItem(value)) return
       var cmp = document.createElement('div')
-      cmp.setAttribute('selected', 'selected')
-      cmp.setAttribute('data-value', option.getAttribute('value'))
-      cmp.innerHTML = option['innerHTML']
+      cmp.setAttribute('data-value', value)
+      cmp.textContent = input.getAttribute('data-label') || value
       this.choiceSelect(cmp, false)
     })
 
-    // ensure all deck values are in select
+    // ensure all deck values have hidden inputs
     Array.from(
       this.deck.querySelectorAll('[data-value]')
     ).forEach((choice) => {
-      if (!this.select.querySelector('option[value="' + choice.getAttribute('data-value') + '"]')) {
+      if (!this.getValueInput(choice.getAttribute('data-value'))) {
         this.choiceSelect(choice, false)
       }
       this.addClear(choice)
@@ -417,12 +405,34 @@ class AutocompleteSelect extends HTMLElement {
     this.input.hidden = this.maxChoices && this.selected.length >= this.maxChoices
   }
 
+  get multiple() {
+    return this.hasAttribute('data-multiple')
+  }
+
   get deck() {
     return this.querySelector('[slot=deck]')
   }
 
-  get select() {
-    return this.querySelector('[slot=select]')
+  get valueInputs() {
+    return this.querySelectorAll('[slot=values]')
+  }
+
+  get searchInput() {
+    return this.querySelector(
+      'autocomplete-select-input [slot=input], autocomplete-light [slot=input]'
+    )
+  }
+
+  get fieldName() {
+    var input = this.querySelector('[slot=values]')
+    if (input) return input.getAttribute('name')
+    var search = this.searchInput
+    if (search) return search.getAttribute('name').replace(/-input$/, '')
+    return null
+  }
+
+  getValueInput(value) {
+    return Array.from(this.valueInputs).find((input) => input.value === value)
   }
 
   get selected() {
@@ -442,18 +452,14 @@ class AutocompleteSelect extends HTMLElement {
   choiceUnselect(choice, noShowHide = false) {
     var value = choice.getAttribute('data-value')
 
-    var option = this.select.querySelector('option[value="' + value + '"]')
-    if (option) {
-      option.removeAttribute('selected')
+    var hidden = this.getValueInput(value)
+    if (hidden) {
+      hidden.parentNode.removeChild(hidden)
     }
 
-    var decked = this.deck.querySelector('[data-value="' + value + '"]')
+    var decked = this.findDeckItem(value)
     if (decked) {
       decked.parentNode.removeChild(decked)
-    }
-
-    if (!this.selected.length) {
-      this.select.value = ''
     }
 
     if (!noShowHide)
@@ -462,15 +468,27 @@ class AutocompleteSelect extends HTMLElement {
     this.changeTrigger()
   }
 
-  choiceUpdate(value, newLabel) {
-    var item = this.deck.querySelector('[data-value="' + value + '"]')
+  choiceUpdate(value, newLabel, newId) {
+    var newValue = value
+    if (newId !== undefined && newId !== null && String(newId) !== String(value)) {
+      newValue = String(newId)
+    }
+    var item = this.findDeckItem(value)
     if (item) {
+      if (newValue !== value) {
+        item.setAttribute('data-value', newValue)
+      }
       var clearSpan = item.querySelector('.clear')
       item.textContent = newLabel
       if (clearSpan) item.appendChild(clearSpan)
     }
-    var option = this.select.querySelector('option[value="' + value + '"]')
-    if (option) option.textContent = newLabel
+    var hidden = this.getValueInput(value)
+    if (hidden) {
+      if (newValue !== value) {
+        hidden.value = newValue
+      }
+      hidden.setAttribute('data-label', newLabel)
+    }
   }
 
   choiceSelect(choice, trigger = true) {
@@ -479,22 +497,29 @@ class AutocompleteSelect extends HTMLElement {
     }
 
     var value = choice.getAttribute('data-value')
+    var label = choice.textContent || choice.innerHTML
 
-    var option = this.select.querySelector('option[value="' + value + '"]')
-    if (!option) {
-      option = document.createElement('option')
-      option.setAttribute('value', value)
-      option.innerHTML = choice.innerHTML
-      this.select.appendChild(option)
-    }
-    option.selected = true
-    option.setAttribute('selected', 'selected')
-
-    if (!this.select.multiple) {
-      this.select.value = value
+    if (!this.multiple) {
+      Array.from(this.valueInputs).forEach((input) => {
+        input.parentNode.removeChild(input)
+      })
+      Array.from(this.deck.querySelectorAll('[data-value]')).forEach((item) => {
+        item.parentNode.removeChild(item)
+      })
     }
 
-    if (!this.deck.querySelector('[data-value="' + value + '"]')) {
+    var hidden = this.getValueInput(value)
+    if (!hidden) {
+      hidden = document.createElement('input')
+      hidden.setAttribute('type', 'hidden')
+      hidden.setAttribute('name', this.fieldName)
+      hidden.setAttribute('value', value)
+      hidden.setAttribute('slot', 'values')
+      hidden.setAttribute('data-label', label)
+      this.deck.parentNode.insertBefore(hidden, this.deck)
+    }
+
+    if (!this.findDeckItem(value)) {
       choice = choice.cloneNode(true)
       choice.classList.remove('hilight')
       this.addClear(choice)
@@ -507,7 +532,7 @@ class AutocompleteSelect extends HTMLElement {
   }
 
   changeTrigger() {
-    this.select.dispatchEvent(
+    this.dispatchEvent(
       new Event('change', {bubbles: true, cancelable: false})
     )
   }
@@ -523,6 +548,12 @@ class AutocompleteSelect extends HTMLElement {
   }
 }
 
-window.customElements.define('autocomplete-light', AutocompleteLight)
-window.customElements.define('autocomplete-select-input', AutocompleteSelectInput)
-window.customElements.define('autocomplete-select', AutocompleteSelect)
+if (!customElements.get('autocomplete-light')) {
+  customElements.define('autocomplete-light', AutocompleteLight)
+}
+if (!customElements.get('autocomplete-select-input')) {
+  customElements.define('autocomplete-select-input', AutocompleteSelectInput)
+}
+if (!customElements.get('autocomplete-select')) {
+  customElements.define('autocomplete-select', AutocompleteSelect)
+}

--- a/src/dal_alight/static/dal_alight/dal-django.js
+++ b/src/dal_alight/static/dal_alight/dal-django.js
@@ -5,10 +5,9 @@
  *  1. Forward: read the dal-forward-conf div emitted by AlightWidgetMixin and
  *     append &forward=<json> to every autocomplete URL request.
  *  2. Create: listen for autocompleteCreate events, POST to the view with the
- *     CSRF token, then feed the returned {id, text} into choiceSelect().
- *  3. Popup sync: when Django admin's "add related" popup creates an object and
- *     adds an option to the native <select>, sync it into the deck via a
- *     change-event listener so the component reflects the new selection.
+ *     CSRF token, then feed the returned HTML fragment into choiceSelect().
+ *  3. Popup sync: when Django admin's "add related" popup creates an object,
+ *     sync it into the deck via choiceSelect().
  */
 
 (function () {
@@ -42,6 +41,12 @@
       return checked.length ? checked : undefined
     }
 
+    // Multiple hidden inputs with the same name (alight multi-select).
+    if (fields.length > 1 && fields.every(function (f) { return f.type === 'hidden' })) {
+      var hiddenValues = fields.map(function (f) { return f.value }).filter(function (v) { return v !== '' })
+      return hiddenValues.length ? hiddenValues : undefined
+    }
+
     var f = fields[0]
     if (f.type === 'checkbox') return f.checked
     if (f.multiple) return Array.from(f.selectedOptions).map(function (o) { return o.value })
@@ -60,8 +65,14 @@
    * formset "name-index" pairs).  The empty prefix (exact match) is always
    * tried last.
    */
+  function getSearchInput(autocompleteSelectEl) {
+    return autocompleteSelectEl.querySelector(
+      'autocomplete-select-input [slot=input], autocomplete-light [slot=input]'
+    )
+  }
+
   function getFormPrefixes(autocompleteSelectEl, form) {
-    var input = autocompleteSelectEl.querySelector('input[name]')
+    var input = getSearchInput(autocompleteSelectEl)
     if (!input) return ['']
     var parts = input.getAttribute('name').replace(/-input$/, '').split('-').slice(0, -1)
     var prefixes = []
@@ -73,6 +84,17 @@
     }
     prefixes.push('')
     return prefixes
+  }
+
+  function getSelfValue(autocompleteSelectEl) {
+    var inputs = Array.from(autocompleteSelectEl.querySelectorAll('[slot=values]'))
+    if (!inputs.length) return undefined
+    var values = inputs.map(function (input) { return input.value }).filter(function (v) { return v !== '' })
+    if (!values.length) return undefined
+    if (autocompleteSelectEl.hasAttribute('data-multiple')) {
+      return values
+    }
+    return values[0]
   }
 
   /**
@@ -95,7 +117,6 @@
     if (!Array.isArray(list) || !list.length) return null
 
     var form = getForm(autocompleteSelectEl)
-    var select = autocompleteSelectEl.querySelector('select')
     var data = {}
 
     list.forEach(function (field) {
@@ -112,7 +133,7 @@
         }
       } else if (field.type === 'self') {
         var dst = field.dst || 'self'
-        if (select) data[dst] = select.value || undefined
+        data[dst] = getSelfValue(autocompleteSelectEl)
       }
     })
 
@@ -169,34 +190,30 @@
   function findAutocompleteSelect(winName) {
     // Django admin's removePopupIndex strips "__N" suffix (double underscore + popup index).
     var name = winName.replace(/__\d+$/, '')
-    var select = document.getElementById(name)
-    if (!select) return null
-    return select.closest('autocomplete-select')
+    var el = document.getElementById(name)
+    if (!el) return null
+    if (el.tagName === 'AUTOCOMPLETE-SELECT') return el
+    return el.closest('autocomplete-select')
   }
 
-  // Defer patching until DOMContentLoaded so that RelatedObjectLookups.js
-  // (which loads after dal-django.js in the merged media) has already run
-  // and defined window.dismissAddRelatedObjectPopup.
   // --- Related-object link enable/disable ----------------------------------
 
   /**
-   * Django admin's updateRelatedObjectLinks uses nextAll() on the <select>
-   * to find .view-related/.change-related buttons.  For our widget the
-   * <select> is nested inside <autocomplete-select>, so the buttons are
-   * siblings of <autocomplete-select>, not of <select>.  We traverse up
-   * first, then look sideways.
+   * Django admin's updateRelatedObjectLinks uses nextAll() on the field
+   * widget to find .view-related/.change-related buttons.  For our widget the
+   * buttons are siblings of <autocomplete-select>, not of the value inputs.
    */
-  function updateAlightRelatedLinks(select) {
-    var acEl = select.closest('autocomplete-select')
+  function updateAlightRelatedLinks(acEl) {
     if (!acEl) return
-    var value = select.value
+    var value = getSelfValue(acEl)
+    var linkValue = Array.isArray(value) ? value[0] : value
     var buttons = acEl.parentNode
       ? Array.from(acEl.parentNode.querySelectorAll('.view-related, .change-related, .delete-related'))
       : []
     buttons.forEach(function (btn) {
-      if (value) {
+      if (linkValue) {
         var tmpl = btn.getAttribute('data-href-template')
-        if (tmpl) btn.setAttribute('href', tmpl.replace('__fk__', value))
+        if (tmpl) btn.setAttribute('href', tmpl.replace('__fk__', linkValue))
         btn.removeAttribute('aria-disabled')
       } else {
         btn.removeAttribute('href')
@@ -208,29 +225,36 @@
   // --- Django admin popup sync -----------------------------------------------
 
   document.addEventListener('DOMContentLoaded', function () {
-    // Initial state for selects that already have a value (edit forms).
-    document.querySelectorAll('autocomplete-select select').forEach(function (select) {
-      updateAlightRelatedLinks(select)
-      select.addEventListener('change', function () {
-        updateAlightRelatedLinks(select)
+    // Initial state for widgets that already have a value (edit forms).
+    document.querySelectorAll('autocomplete-select').forEach(function (acEl) {
+      updateAlightRelatedLinks(acEl)
+      acEl.addEventListener('change', function () {
+        updateAlightRelatedLinks(acEl)
       })
     })
     var origAdd = window.dismissAddRelatedObjectPopup
     window.dismissAddRelatedObjectPopup = function (win, newId, newRepr) {
-      if (origAdd) origAdd.call(this, win, newId, newRepr)
       var el = findAutocompleteSelect(win.name)
-      if (!el) return
-      var choice = document.createElement('div')
-      choice.setAttribute('data-value', String(newId))
-      choice.textContent = String(newRepr)
-      el.choiceSelect(choice)
+      if (el) {
+        var choice = document.createElement('div')
+        choice.setAttribute('data-value', String(newId))
+        choice.textContent = String(newRepr)
+        el.choiceSelect(choice)
+        win.close()
+        return
+      }
+      if (origAdd) origAdd.call(this, win, newId, newRepr)
     }
 
     var origChange = window.dismissChangeRelatedObjectPopup
     window.dismissChangeRelatedObjectPopup = function (win, objId, newRepr, newId) {
-      if (origChange) origChange.call(this, win, objId, newRepr, newId)
       var el = findAutocompleteSelect(win.name)
-      if (el) el.choiceUpdate(String(objId), String(newRepr))
+      if (el) {
+        el.choiceUpdate(String(objId), String(newRepr), String(newId))
+        win.close()
+        return
+      }
+      if (origChange) origChange.call(this, win, objId, newRepr, newId)
     }
   })
 })()

--- a/src/dal_alight/test.py
+++ b/src/dal_alight/test.py
@@ -2,6 +2,8 @@
 
 import time
 
+from dal.test import stories
+
 
 class AlightStory:
     """CSS selectors and wait logic for the autocomplete-light web component.
@@ -12,12 +14,13 @@ class AlightStory:
     HTML structure produced by ``AlightWidgetMixin``::
 
         <autocomplete-select>
-          <select slot="select" id="id_{field}">…</select>
-          <div slot="deck">
+          <input type="hidden" name="{field}" value="1"
+                 slot="values" data-label="Label">
+          <span slot="deck">
             <div data-value="1">Label<span class="clear">×</span></div>
-          </div>
+          </span>
           <autocomplete-select-input slot="input" url="…">
-            <input name="{field}-input" slot="input" class="vTextField" />
+            <input id="id_{field}" name="{field}-input" slot="input" />
           </autocomplete-select-input>
         </autocomplete-select>
 
@@ -28,10 +31,6 @@ class AlightStory:
           <div data-create data-value="foo">Create "foo"</div>
         </div>
     """
-
-    # The text input lives inside the widget, not in a global dropdown.
-    # This lets InlineSelectOption scope enter_text to the field container.
-    input_in_field_container = True
 
     # Text input embedded inside the web component.
     input_selector = 'autocomplete-select-input input'
@@ -111,3 +110,85 @@ class AlightStory:
     def clean_label(self, label):
         """Remove the × clear button text from a label string."""
         return label.replace('×', '').strip()
+
+
+class AlightSelectOption(stories.SelectOption):
+    """Single-select user story for the alight backend."""
+
+    def _values_selector(self):
+        """Hidden inputs live in the component; Django's id is on the search input."""
+        return 'autocomplete-select:has(%s) [slot=values]' % self.field_selector
+
+    def get_value(self):
+        fields = self.case.browser.find_by_css(self._values_selector())
+        if not fields:
+            return ''
+        return fields.first['value']
+
+
+class AlightMultipleMixin(stories.MultipleMixin):
+    """Multiple-select assertions using alight hidden value inputs."""
+
+    def get_values(self):
+        script = """
+        window.GET_VALUES = [];
+        document.querySelectorAll("%s").forEach(function(inp) {
+            GET_VALUES.push(inp.value);
+        });
+        """ % self._values_selector()
+        self.case.browser.execute_script(script)
+        return self.case.browser.evaluate_script('window.GET_VALUES')
+
+
+class AlightSelectOptionMultiple(AlightMultipleMixin, AlightSelectOption):
+    """Multiple-select user story for the alight backend."""
+
+
+class AlightInlineSelectOption(
+    stories.InlineSelectOptionMixin,
+    AlightSelectOption,
+):
+    """Single-select user story for alight inlines."""
+
+    def _scope_inline_input_selector(self):
+        self.input_selector = '%s %s' % (
+            self.field_container_selector,
+            self.input_selector,
+        )
+
+
+class AlightInlineSelectOptionMultiple(
+    AlightMultipleMixin,
+    AlightInlineSelectOption,
+):
+    """Multiple-select user story for alight inlines."""
+
+
+class AlightCreateOption(AlightSelectOption, stories.CreateOption):
+    """Create an option on the fly — alight backend only."""
+
+    def create_option(self, name):
+        create_sel = self.case.get_create_option_selector(name)
+        self._open_and_type(name)
+        self.case.browser.is_element_present_by_css(create_sel)
+        value_selector = self._values_selector()
+        initial_count = self.case.browser.evaluate_script(
+            'document.querySelectorAll("%s").length' % value_selector
+        )
+        self.case.js_click(create_sel)
+        deadline = time.time() + 5
+        while time.time() < deadline:
+            count = self.case.browser.evaluate_script(
+                'document.querySelectorAll("%s").length' % value_selector
+            )
+            if count > initial_count:
+                break
+            if self.case.browser.is_element_present_by_css(
+                '.invalid-feedback', wait_time=0,
+            ):
+                break
+            time.sleep(0.1)
+
+
+class AlightCreateOptionMultiple(AlightMultipleMixin, AlightCreateOption):
+    """Multiple-select variant of :class:`AlightCreateOption`."""

--- a/src/dal_alight/widgets.py
+++ b/src/dal_alight/widgets.py
@@ -1,10 +1,11 @@
-import django
 from django import forms
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 
 from dal.widgets import QuerySetSelectMixin, WidgetMixin
+
+from .media import alight_media
 
 
 def _is_iterable(x):
@@ -32,26 +33,7 @@ class AlightWidgetMixin:
 
     @property
     def media(self):
-        # Django 6+ forms.Media supports Script(type="module"), which ensures
-        # each URL executes once when multiple widgets merge media
-        # (customElements.define must not run twice).  On older Django versions
-        # we fall back to plain script paths.
-        if django.VERSION >= (6, 0):
-            from django.forms.widgets import Script
-
-            js = [
-                Script('dal_alight/autocomplete-light.js', type='module'),
-                Script('dal_alight/dal-django.js', type='module'),
-            ]
-        else:
-            js = [
-                'dal_alight/autocomplete-light.js',
-                'dal_alight/dal-django.js',
-            ]
-        return forms.Media(
-            css=dict(all=['dal_alight/autocomplete-light.css']),
-            js=js,
-        )
+        return alight_media()
 
     def render(self, name, value, attrs=None, renderer=None, **kwargs):
         if hasattr(self.choices, 'field'):

--- a/src/dal_alight/widgets.py
+++ b/src/dal_alight/widgets.py
@@ -1,7 +1,7 @@
 from django import forms
+from django.forms.widgets import ChoiceWidget
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
-from django.utils.translation import gettext_lazy as _
 
 from dal.widgets import QuerySetSelectMixin, WidgetMixin
 
@@ -16,52 +16,142 @@ def _is_iterable(x):
     return True
 
 
+class AlightChoiceMixin(ChoiceWidget):
+    """Choice plumbing for Alight widgets; rendering is in AlightWidgetMixin."""
+
+    # ChoiceWidget sets template_name = None; keep TextInput rendering working.
+    template_name = 'django/forms/widgets/text.html'
+    input_type = 'text'
+
+    def get_context(self, name, value, attrs):
+        """Text input context for the search field (no ChoiceWidget optgroups)."""
+        context = super(ChoiceWidget, self).get_context(name, value, attrs)
+        # Search input is always empty; ChoiceWidget.format_value would list-wrap.
+        context["widget"]["value"] = forms.TextInput.format_value(self, value)
+        return context
+
+
+class AlightMultipleMixin:
+    """Multiple-selection behaviour for hidden value inputs."""
+
+    allow_multiple_selected = True
+
+    def value_from_datadict(self, data, files, name):
+        try:
+            return data.getlist(name)
+        except AttributeError:
+            val = data.get(name)
+            if val is None:
+                return []
+            if isinstance(val, list):
+                return val
+            return [val]
+
+
 class AlightWidgetMixin:
     """Mixin that renders the autocomplete-light web component shell.
 
-    Wraps the underlying ``<select>`` (rendered by ``super().render()``) in::
-
-        <autocomplete-select>
-          <select slot="select">…</select>
-          <div slot="deck"></div>
-          <autocomplete-select-input slot="input" [url="…"]>
-            <input …/>
-          </autocomplete-select-input>
-          <div class="dal-forward-conf">…</div>
-        </autocomplete-select>
+    The visible search field is a ``TextInput``; callers configure it with the
+    usual widget ``attrs``.  Selected values are stored in hidden
+    ``slot="values"`` inputs.
     """
 
     @property
     def media(self):
         return alight_media()
 
+    def _iter_selected_options(self, name, value, attrs=None):
+        """Yield selected options as flat dicts for deck/hidden inputs.
+
+        Alight has no optgroup UI; this hides Django's grouped optgroups() API.
+        """
+        for _group, options, _index in self.optgroups(name, value, attrs=attrs):
+            for option in options:
+                if not option['selected']:
+                    continue
+                val = option['value']
+                if val is None or val == '':
+                    continue
+                yield option
+
+    def _render_values_and_deck(self, name, value, attrs=None):
+        """Build hidden inputs and deck chips for the current selection."""
+        value = self.format_value(value)
+        hidden_parts = []
+        deck_parts = []
+        disabled = mark_safe(' disabled') if attrs and attrs.get('disabled') else ''
+        for option in self._iter_selected_options(name, value, attrs=attrs):
+            val = option['value']
+            label = option['label']
+            hidden_parts.append(format_html(
+                '<input type="hidden" name="{}" value="{}" slot="values" '
+                'data-label="{}"{}>',
+                name,
+                val,
+                label,
+                disabled,
+            ))
+            deck_parts.append(format_html(
+                '<div data-value="{}">{}</div>',
+                val,
+                label,
+            ))
+        values_html = mark_safe(''.join(hidden_parts))
+        if deck_parts:
+            deck_html = format_html(
+                '<span slot="deck">{}</span>',
+                mark_safe(''.join(deck_parts)),
+            )
+        else:
+            deck_html = '<span slot="deck"></span>'
+        return values_html, deck_html
+
+    def _render_search_input(self, name, attrs, renderer=None, **kwargs):
+        """Render the visible search input via the TextInput ``render()`` MRO."""
+        # BoundField puts ``required`` in attrs for the field widget.  The search
+        # input is auxiliary (values submit via hidden inputs); strip it so the
+        # browser does not run HTML5 validation on an empty search box.
+        search_attrs = {k: v for k, v in attrs.items() if k != 'required'}
+        search_attrs['slot'] = 'input'
+        search_attrs['autocomplete'] = 'off'
+        return super(AlightChoiceMixin, self).render(
+            f'{name}-input',
+            '',
+            attrs=search_attrs,
+            renderer=renderer,
+            **kwargs,
+        )
+
     def render(self, name, value, attrs=None, renderer=None, **kwargs):
         if hasattr(self.choices, 'field'):
             self.choices.field.empty_label = None
-        attrs = attrs or {}
-        attrs.setdefault('slot', 'select')
+        final_attrs = self.build_attrs(self.attrs, attrs)
+        field_id = final_attrs.get('id') or name
 
-        widget = super().render(name, value, attrs=attrs, renderer=renderer, **kwargs)
+        values_html, deck_html = self._render_values_and_deck(
+            name, value, attrs=final_attrs
+        )
 
-        deck = '<span slot="deck"></span>'
         url_attr = format_html(' url="{}"', self.url) if self.url else ''
-        input_widget = forms.TextInput(attrs={
-            'name': f'{name}-input',
-            'slot': 'input',
-            'class': 'vTextField',
-            'placeholder': _('Search'),
-            'autocomplete': 'off',
-        })
-        input_html = input_widget.render(f'{name}-input', '', renderer=renderer)
+        input_html = self._render_search_input(
+            name, final_attrs, renderer=renderer, **kwargs
+        )
         input_el = format_html(
             '<autocomplete-select-input slot="input"{}>{}</autocomplete-select-input>',
             url_attr,
             input_html,
         )
-        field_id = (attrs or {}).get('id') or name
         conf = self.render_forward_conf(field_id)
-        inner = widget + deck + str(input_el) + conf
-        return mark_safe(f'<autocomplete-select>{inner}</autocomplete-select>')
+
+        multiple_attr = (
+            ' data-multiple' if getattr(self, 'allow_multiple_selected', False) else ''
+        )
+        inner = values_html + deck_html + str(input_el) + conf
+        return mark_safe(format_html(
+            '<autocomplete-select{}>{}</autocomplete-select>',
+            mark_safe(multiple_attr),
+            mark_safe(inner),
+        ))
 
 
 # ---------------------------------------------------------------------------
@@ -69,55 +159,62 @@ class AlightWidgetMixin:
 # ---------------------------------------------------------------------------
 
 class ModelAlight(
-    QuerySetSelectMixin,
     AlightWidgetMixin,
-    forms.Select,
+    QuerySetSelectMixin,
+    AlightChoiceMixin,
+    forms.TextInput,
 ):
     """Single-select autocomplete widget backed by a QuerySet."""
 
 
 class ModelAlightMultiple(
-    QuerySetSelectMixin,
     AlightWidgetMixin,
-    forms.SelectMultiple,
+    QuerySetSelectMixin,
+    AlightMultipleMixin,
+    AlightChoiceMixin,
+    forms.TextInput,
 ):
     """Multi-select autocomplete widget backed by a QuerySet."""
 
 
 # ---------------------------------------------------------------------------
-# Non-queryset widgets (arbitrary choice lists)
+# List-backed widgets (non-queryset)
 # ---------------------------------------------------------------------------
 
-class Alight(WidgetMixin, AlightWidgetMixin, forms.Select):
-    """Single-select autocomplete for arbitrary choices.
-
-    Without a ``url`` the component filters ``<option>`` elements locally in
-    JS — no server round-trip needed.  With a ``url`` it fetches from the
-    view as usual.
-    """
-
-
-class AlightMultiple(WidgetMixin, AlightWidgetMixin, forms.SelectMultiple):
-    """Multiple-select autocomplete for arbitrary choices."""
-
-
-class ListAlight(WidgetMixin, AlightWidgetMixin, forms.Select):
+class ListAlight(
+    AlightWidgetMixin,
+    WidgetMixin,
+    AlightChoiceMixin,
+    forms.TextInput,
+):
     """Single-select autocomplete backed by ``AlightListView``.
 
     Use alongside ``AlightListView`` on the server.
     """
+
+    def __init__(self, url=None, *args, **kwargs):
+        if url is None and args and isinstance(args[0], str):
+            url = args[0]
+        if not url:
+            raise ValueError(
+                '{} requires a url; client-side local filtering was removed.'
+                .format(self.__class__.__name__)
+            )
+        super().__init__(url, *args, **kwargs)
 
 
 # ---------------------------------------------------------------------------
 # Tag widget
 # ---------------------------------------------------------------------------
 
-class TagAlight(WidgetMixin, AlightWidgetMixin, forms.SelectMultiple):
+class TagAlight(
+    AlightWidgetMixin,
+    WidgetMixin,
+    AlightMultipleMixin,
+    AlightChoiceMixin,
+    forms.TextInput,
+):
     """Free-text tag widget — value stored as comma-separated text.
-
-    AlightInitialRenderMixin is intentionally omitted: tags are not PKs so
-    the queryset-filter approach would break; optgroups() handles initial
-    values directly via _iter_tag_values().
 
     Tags are not backed by a model: the tag text IS the option value.
     Use alongside ``AlightListView`` with a ``create()`` method, or any view
@@ -155,12 +252,9 @@ class TagAlight(WidgetMixin, AlightWidgetMixin, forms.SelectMultiple):
                 continue
             yield self.option_value(str(v).strip())
 
-    def optgroups(self, name, value, attrs=None):
-        default = (None, [], 0)
-        groups = [default]
-        for i, v in enumerate(self._iter_tag_values(value)):
-            default[1].append(self.create_option(v, v, v, True, i))
-        return groups
+    def _iter_selected_options(self, name, value, attrs=None):
+        for v in self._iter_tag_values(value):
+            yield {'value': v, 'label': v, 'selected': True}
 
     def value_from_datadict(self, data, files, name):
         values = super().value_from_datadict(data, files, name)
@@ -170,11 +264,9 @@ class TagAlight(WidgetMixin, AlightWidgetMixin, forms.SelectMultiple):
 class TaggitAlight(TagAlight):
     def value_from_datadict(self, data, files, name):
         value = super().value_from_datadict(data, files, name)
-        # trailing comma keeps multi-word single tags intact for taggit's parser
         if value and ',' not in value:
             value = '%s,' % value
         return value
 
     def option_value(self, value):
-        # taggit may yield TaggedItem objects on initial render
         return value.tag.name if hasattr(value, 'tag') else value

--- a/src/dal_alight_queryset_sequence/widgets.py
+++ b/src/dal_alight_queryset_sequence/widgets.py
@@ -3,32 +3,30 @@ Widgets for autocomplete-light and QuerySetSequence.
 
 They combine :py:class:`~dal_alight.widgets.AlightWidgetMixin` and
 :py:class:`~dal_queryset_sequence.widgets.QuerySetSequenceSelectMixin` with
-Django's Select and SelectMultiple widgets, and are meant to be used with
-generic model form fields such as those in :py:mod:`dal_contenttypes.fields`.
+Django's TextInput widget, and are meant to be used with generic model form
+fields such as those in :py:mod:`dal_contenttypes.fields`.
 """
 
 from django import forms
 
-from dal_alight.widgets import AlightWidgetMixin
+from dal_alight.widgets import AlightChoiceMixin, AlightMultipleMixin, AlightWidgetMixin
 from dal_queryset_sequence.widgets import QuerySetSequenceSelectMixin
-
-# AlightInitialRenderMixin is intentionally NOT included: it filters
-# self.choices.queryset by pk__in=[…], which breaks on the composite
-# "ctype_pk-object_pk" values used by dal_queryset_sequence.
-# WidgetMixin.optgroups() → filter_choices_to_render() decodes them correctly.
 
 
 class QuerySetSequenceAlight(
-    QuerySetSequenceSelectMixin,
     AlightWidgetMixin,
-    forms.Select,
+    QuerySetSequenceSelectMixin,
+    AlightChoiceMixin,
+    forms.TextInput,
 ):
     """Single-select autocomplete-light widget for QuerySetSequence."""
 
 
 class QuerySetSequenceAlightMultiple(
-    QuerySetSequenceSelectMixin,
     AlightWidgetMixin,
-    forms.SelectMultiple,
+    QuerySetSequenceSelectMixin,
+    AlightMultipleMixin,
+    AlightChoiceMixin,
+    forms.TextInput,
 ):
     """Multi-select autocomplete-light widget for QuerySetSequence."""

--- a/src/dal_select2/test.py
+++ b/src/dal_select2/test.py
@@ -2,6 +2,8 @@
 
 import time
 
+from dal.test import stories
+
 
 class Select2Story(object):
     """Define Select2 CSS selectors."""
@@ -30,3 +32,83 @@ class Select2Story(object):
     def clean_label(self, label):
         """Remove the "remove" character used in select2."""
         return label.replace('\xd7', '')
+
+
+class Select2SelectOption(stories.SelectOption):
+    """Single-select user story for the select2 backend."""
+
+    def get_value(self):
+        field = self.case.browser.find_by_css(self.field_selector)
+        return field.first['value']
+
+
+class Select2MultipleMixin(stories.MultipleMixin):
+    """Multiple-select assertions for select2 ``<select>`` widgets."""
+
+    def get_values(self):
+        script = """
+        window.GET_VALUES = [];
+        document.querySelectorAll("%s option:checked").forEach(function(opt) {
+            GET_VALUES.push(opt.value);
+        });
+        """ % self.field_selector
+        self.case.browser.execute_script(script)
+        return self.case.browser.evaluate_script('window.GET_VALUES')
+
+
+class Select2SelectOptionMultiple(Select2MultipleMixin, Select2SelectOption):
+    """Multiple-select user story for the select2 backend."""
+
+
+class Select2InlineSelectOption(
+    stories.InlineSelectOptionMixin,
+    Select2SelectOption,
+):
+    """Single-select user story for select2 inlines."""
+
+    def _scope_inline_input_selector(self):
+        pass
+
+
+class Select2InlineSelectOptionMultiple(
+    Select2MultipleMixin,
+    Select2InlineSelectOption,
+):
+    """Multiple-select user story for select2 inlines."""
+
+    def __init__(self, case, inline_number, inline_related_name=None,
+                 **kwargs):
+        super().__init__(
+            case,
+            inline_number,
+            inline_related_name=inline_related_name,
+            **kwargs
+        )
+        self.input_selector = '%s %s' % (
+            self.field_container_selector,
+            self.input_selector,
+        )
+
+
+class Select2CreateOption(Select2SelectOption, stories.CreateOption):
+    """Create an option on the fly — select2 backend only."""
+
+    def create_option(self, name):
+        self._open_and_type(name)
+        self.case.browser.is_element_present_by_text(name)
+        self.case.click(self.option_selector)
+        self.case.browser.is_element_not_present_by_css(
+            '.select2-results__options'
+        )
+
+
+class Select2CreateOptionMultiple(Select2MultipleMixin, Select2CreateOption):
+    """Multiple-select create-on-the-fly for the select2 backend."""
+
+
+class Select2RenameOption(Select2SelectOption, stories.RenameOption):
+    """Rename related object via admin popup — select2 backend."""
+
+
+class Select2AddAnotherOption(Select2SelectOption, stories.AddAnotherOption):
+    """Add related object via admin popup — select2 backend."""

--- a/src/dal_select2/widgets.py
+++ b/src/dal_select2/widgets.py
@@ -54,8 +54,15 @@ class Select2WidgetMixin(object):
     """Mixin for Select2 widgets."""
 
     def build_attrs(self, *args, **kwargs):
-        """Set data-autocomplete-light-language."""
+        """Set Select2 data-* attributes for autocomplete_light.js."""
         attrs = super(Select2WidgetMixin, self).build_attrs(*args, **kwargs)
+        if self.url is not None:
+            attrs['data-autocomplete-light-url'] = self.url
+        if getattr(self, 'autocomplete_function', None):
+            attrs.setdefault(
+                'data-autocomplete-light-function',
+                self.autocomplete_function,
+            )
         lang_code = self._get_language_code()
         if lang_code:
             attrs.setdefault('data-autocomplete-light-language', lang_code)

--- a/test_project/alight_foreign_key/test_functional.py
+++ b/test_project/alight_foreign_key/test_functional.py
@@ -1,5 +1,5 @@
-from dal.test import case, stories
-from dal_alight.test import AlightStory
+from dal.test import case
+from dal_alight.test import AlightInlineSelectOption, AlightSelectOption, AlightStory
 
 from .models import TModel
 
@@ -21,25 +21,25 @@ class AdminForeignKeyTestCase(
 
     def test_can_select_option(self):
         option = self.create_option()
-        story = stories.SelectOption(self)
+        story = AlightSelectOption(self)
         story.select_option(option.name)
         story.assert_selection_persists(option.pk, option.name)
 
     def test_can_select_option_in_first_inline(self):
         option = self.create_option()
-        story = stories.InlineSelectOption(self, inline_number=0)
+        story = AlightInlineSelectOption(self, inline_number=0)
         story.select_option(option.name)
         story.assert_selection(option.pk, option.name)
 
     def test_can_select_option_in_first_extra_inline(self):
         option = self.create_option()
-        story = stories.InlineSelectOption(self, inline_number=3)
+        story = AlightInlineSelectOption(self, inline_number=3)
         story.select_option(option.name)
         story.assert_selection(option.pk, option.name)
 
     def test_can_unselect_option(self):
         option = self.create_option()
-        story = stories.SelectOption(self)
+        story = AlightSelectOption(self)
         story.select_option(option.name)
         story.submit()
         story.clear_option()
@@ -51,6 +51,6 @@ class AdminForeignKeyTestCase(
         # Save a record with the option selected.
         instance = self.model.objects.create(name='edit_me', test=option)
         self.get(url=self.get_modeladmin_url('change', object_id=instance.pk))
-        story = stories.SelectOption(self)
+        story = AlightSelectOption(self)
         story.assert_label(option.name)
         story.assert_value(option.pk)

--- a/test_project/alight_foreign_key/test_units.py
+++ b/test_project/alight_foreign_key/test_units.py
@@ -1,6 +1,7 @@
 """Unit tests for dal_alight views, widgets, and fields."""
 
 
+from django import forms
 from django.contrib.auth import get_user_model
 from django.test import RequestFactory, TestCase
 
@@ -12,8 +13,6 @@ from dal_alight.views import (
     AlightQuerySetView,
 )
 from dal_alight.widgets import (
-    Alight,
-    AlightMultiple,
     ListAlight,
     ModelAlight,
     ModelAlightMultiple,
@@ -333,6 +332,108 @@ class AlightWidgetMixinMediaTest(TestCase):
             self.assertIn('type="module"', media_js[idx:end])
 
 
+class AlightSearchInputAttrsTest(TestCase):
+    """Search input receives standard widget attrs (TextInput base)."""
+
+    def setUp(self):
+        self.TModel = get_tmodel()
+
+    def _bound_widget(self, label='Country', **widget_kw):
+        from django.forms import ModelChoiceField
+        field = ModelChoiceField(
+            queryset=self.TModel.objects.all(),
+            label=label,
+        )
+        w = ModelAlight(url='alight_fk', **widget_kw)
+        w.choices = field.widget.choices
+        w.choices.field = field
+        return w
+
+    def test_is_text_input_not_select(self):
+        w = self._bound_widget()
+        self.assertIsInstance(w, forms.TextInput)
+        self.assertNotIsInstance(w, forms.Select)
+
+    def test_no_forced_vtextfield_class(self):
+        w = self._bound_widget()
+        html = w.render('test', None, attrs={'id': 'id_test'})
+        self.assertNotIn('vTextField', html)
+
+    def test_attrs_class_from_init(self):
+        w = self._bound_widget(attrs={'class': 'my-input'})
+        html = w.render('test', None, attrs={'id': 'id_test'})
+        self.assertIn('class="my-input"', html)
+
+    def test_render_attrs_class_from_render_attrs(self):
+        w = self._bound_widget()
+        html = w.render(
+            'test', None, attrs={'id': 'id_test', 'class': 'render-class'},
+        )
+        self.assertIn('class="render-class"', html)
+
+    def test_attrs_placeholder_from_widget_attrs(self):
+        w = self._bound_widget(label='Country')
+        html = w.render(
+            'test', None,
+            attrs={'id': 'id_test', 'placeholder': 'Pick one…'},
+        )
+        self.assertIn('placeholder="Pick one…"', html)
+
+    def test_slot_input_always_set(self):
+        w = self._bound_widget(attrs={'slot': 'evil'})
+        html = w.render('test', None, attrs={'id': 'id_test'})
+        self.assertIn('slot="input"', html)
+        self.assertNotIn('slot="evil"', html)
+
+    def test_list_alight_attrs_apply(self):
+        w = ListAlight(
+            url='/list-autocomplete/',
+            choices=[('a', 'Alpha')],
+            attrs={'class': 'plain-alight'},
+        )
+        html = w.render('field', None, attrs={'id': 'id_field'})
+        self.assertIn('class="plain-alight"', html)
+
+    def test_no_select2_data_attrs_on_search_input(self):
+        w = self._bound_widget()
+        html = w.render('test', None, attrs={'id': 'id_test'})
+        self.assertIn('url="', html)
+        self.assertNotIn('data-autocomplete-light-url', html)
+
+    def test_aria_describedby_passes_through(self):
+        w = self._bound_widget()
+        html = w.render(
+            'test', None,
+            attrs={'id': 'id_test', 'aria-describedby': 'id_test_helptext'},
+        )
+        self.assertIn('aria-describedby="id_test_helptext"', html)
+
+    def test_disabled_passes_through(self):
+        w = self._bound_widget(attrs={'disabled': True})
+        html = w.render('test', None, attrs={'id': 'id_test'})
+        self.assertIn('disabled', html)
+
+    def test_data_attr_passes_through(self):
+        w = self._bound_widget(attrs={'data-foo': 'bar'})
+        html = w.render('test', None, attrs={'id': 'id_test'})
+        self.assertIn('data-foo="bar"', html)
+
+    def test_required_not_on_search_input(self):
+        from django.forms import ModelChoiceField
+        field = ModelChoiceField(
+            queryset=self.TModel.objects.all(),
+            required=True,
+        )
+        w = ModelAlight(url='alight_fk')
+        w.choices = field.widget.choices
+        w.choices.field = field
+        html = w.render('test', None, attrs={'id': 'id_test'})
+        self.assertNotRegex(
+            html,
+            r'<input type="text"[^>]*\srequired(?:\s|>|=)',
+        )
+
+
 class ModelAlightRenderTest(TestCase):
     def setUp(self):
         self.TModel = get_tmodel()
@@ -348,13 +449,20 @@ class ModelAlightRenderTest(TestCase):
     def test_renders_autocomplete_select_wrapper(self):
         w = self._widget()
         html = w.render('test', None)
-        self.assertIn('<autocomplete-select>', html)
+        self.assertIn('<autocomplete-select', html)
         self.assertIn('</autocomplete-select>', html)
 
-    def test_renders_select_with_slot(self):
+    def test_renders_id_on_search_input(self):
+        w = self._widget()
+        html = w.render('test', None, attrs={'id': 'id_test'})
+        self.assertIn('id="id_test"', html)
+        self.assertNotIn('<autocomplete-select id=', html)
+
+    def test_renders_hidden_values_slot(self):
         w = self._widget()
         html = w.render('test', None)
-        self.assertIn('slot="select"', html)
+        self.assertNotIn('slot="select"', html)
+        self.assertNotIn('<select', html)
 
     def test_renders_deck_span(self):
         w = self._widget()
@@ -421,6 +529,8 @@ class AlightInitialRenderMixinTest(TestCase):
     def test_prefills_single_value(self):
         html = self._widget(self.obj.pk)
         self.assertIn('pre-filled', html)
+        self.assertIn('slot="values"', html)
+        self.assertIn('type="hidden"', html)
 
     def test_does_not_fail_on_none_value(self):
         html = self._widget(None)
@@ -441,30 +551,19 @@ class AlightInitialRenderMixinTest(TestCase):
         self.assertIn('second', html)
 
 
-class NonQuerysetWidgetTest(TestCase):
-    """Alight, AlightMultiple, ListAlight render correctly."""
+class ListAlightWidgetTest(TestCase):
+    """ListAlight render and url requirements."""
 
     CHOICES = [('a', 'Alpha'), ('b', 'Beta')]
 
-    def test_alight_renders_component(self):
-        # Use a path (contains '/') so WidgetMixin doesn't try to reverse it.
-        w = Alight(url='/autocomplete/', choices=self.CHOICES)
-        html = w.render('field', None, attrs={'id': 'id_field'})
-        self.assertIn('<autocomplete-select>', html)
-
-    def test_alight_without_url_no_url_attr(self):
-        w = Alight(url=None, choices=self.CHOICES)
-        html = w.render('field', None, attrs={'id': 'id_field'})
-        # Should render without url="…" on the input element.
-        self.assertNotIn('url="', html)
-
-    def test_alight_multiple_allow_multiple(self):
-        w = AlightMultiple(url=None, choices=self.CHOICES)
-        self.assertTrue(w.allow_multiple_selected)
+    def test_list_alight_without_url_raises(self):
+        with self.assertRaises(ValueError):
+            ListAlight(url=None, choices=self.CHOICES)
 
     def test_list_alight_renders_component(self):
         w = ListAlight(url='/list-autocomplete/', choices=self.CHOICES)
         html = w.render('field', None, attrs={'id': 'id_field'})
+        self.assertIn('id="id_field"', html)
         self.assertIn('url="', html)
 
 
@@ -492,10 +591,9 @@ class TagAlightTest(TestCase):
         result = w.format_value(['foo', 'bar'])
         self.assertEqual(result, {'foo', 'bar'})
 
-    def test_optgroups_creates_selected_options(self):
+    def test_iter_selected_options_yields_flat_tags(self):
         w = self._widget()
-        groups = w.optgroups('tags', 'foo,bar')
-        options = groups[0][1]
+        options = list(w._iter_selected_options('tags', 'foo,bar'))
         values = [o['value'] for o in options]
         self.assertIn('foo', values)
         self.assertIn('bar', values)
@@ -505,7 +603,7 @@ class TagAlightTest(TestCase):
     def test_render_includes_component(self):
         w = self._widget()
         html = w.render('tags', 'foo,bar', attrs={'id': 'id_tags'})
-        self.assertIn('<autocomplete-select>', html)
+        self.assertIn('id="id_tags"', html)
 
     def test_allow_multiple_selected(self):
         self.assertTrue(self._widget().allow_multiple_selected)

--- a/test_project/alight_foreign_key/test_units.py
+++ b/test_project/alight_foreign_key/test_units.py
@@ -254,6 +254,52 @@ class AlightListViewTest(TestCase):
 # Widget render tests
 # ---------------------------------------------------------------------------
 
+class AlightMediaTest(TestCase):
+    """Module script media via Django Script or dal_alight backport."""
+
+    def test_backport_script_renders_module_type(self):
+        from dal_alight.media import Script as BackportScript
+
+        tag = str(BackportScript('dal_alight/autocomplete-light.js', type='module'))
+        self.assertIn('type="module"', tag)
+        self.assertIn('autocomplete-light.js', tag)
+
+    def test_alight_media_uses_script_instances(self):
+        from dal_alight.media import alight_media, get_script_class
+
+        media = alight_media()
+        script_cls = get_script_class()
+        for path in media._js:
+            self.assertIsInstance(path, script_cls)
+
+    def test_get_script_class_returns_django_script_when_available(self):
+        from dal_alight.media import Script as BackportScript
+        from dal_alight.media import get_script_class
+
+        try:
+            from django.forms.widgets import Script as DjangoScript
+        except ImportError:
+            self.assertIs(get_script_class(), BackportScript)
+            return
+        self.assertIs(get_script_class(), DjangoScript)
+
+    def test_script_dedupes_with_plain_path_in_media_merge(self):
+        from django.forms.widgets import Media
+
+        from dal_alight.media import Script as BackportScript
+
+        script = BackportScript('dal_alight/autocomplete-light.js', type='module')
+        merged = Media.merge(
+            [script, 'dal_alight/dal-django.js'],
+            ['dal_alight/autocomplete-light.js'],
+        )
+        paths = [
+            item if isinstance(item, str) else item._path
+            for item in merged
+        ]
+        self.assertEqual(paths.count('dal_alight/autocomplete-light.js'), 1)
+
+
 class AlightWidgetMixinMediaTest(TestCase):
     def test_media_includes_autocomplete_js(self):
         w = ModelAlight(url='x')
@@ -270,15 +316,21 @@ class AlightWidgetMixinMediaTest(TestCase):
         media_css = str(w.media)
         self.assertIn('autocomplete-light.css', media_css)
 
-    def test_media_uses_module_scripts_on_django_6(self):
-        import django
-
+    def test_media_uses_module_scripts(self):
         w = ModelAlight(url='x')
         media_js = str(w.media)
-        if django.VERSION >= (6, 0):
-            self.assertIn('type="module"', media_js)
-        else:
-            self.assertNotIn('type="module"', media_js)
+        self.assertIn('type="module"', media_js)
+        self.assertEqual(media_js.count('type="module"'), 2)
+
+    def test_media_module_scripts_for_both_js_files(self):
+        w = ModelAlight(url='x')
+        media_js = str(w.media)
+        self.assertIn('autocomplete-light.js', media_js)
+        self.assertIn('dal-django.js', media_js)
+        for path in ('autocomplete-light.js', 'dal-django.js'):
+            idx = media_js.index(path)
+            end = media_js.index('</script>', idx)
+            self.assertIn('type="module"', media_js[idx:end])
 
 
 class ModelAlightRenderTest(TestCase):

--- a/test_project/alight_generic_foreign_key/test_forms.py
+++ b/test_project/alight_generic_foreign_key/test_forms.py
@@ -76,8 +76,8 @@ class GenericFormTest(test.TestCase):  # noqa
         # Ensure that the widget rendered right, with the alight component
         result = str(form['test'].as_widget())
 
-        # Alight widget wraps the select in <autocomplete-select>
-        self.assertIn('<autocomplete-select>', result)
+        # Alight widget renders an <autocomplete-select> web component.
+        self.assertIn('id="id_test"', result)
         self.assertIn('</autocomplete-select>', result)
 
         # The autocomplete URL for this field should be present

--- a/test_project/alight_generic_foreign_key/test_functional.py
+++ b/test_project/alight_generic_foreign_key/test_functional.py
@@ -1,5 +1,5 @@
-from dal.test import case, stories
-from dal_alight.test import AlightStory
+from dal.test import case
+from dal_alight.test import AlightInlineSelectOption, AlightSelectOption, AlightStory
 
 from .models import TModel
 
@@ -18,7 +18,7 @@ class AdminGenericForeignKeyTestCase(AlightStory, case.AdminMixin,
 
     def test_can_select_option(self):
         option, ctype = self.create_option()
-        story = stories.SelectOption(self)
+        story = AlightSelectOption(self)
         story.select_option(option.name)
         story.assert_selection_persists(
             '%s-%s' % (ctype.pk, option.pk),
@@ -27,7 +27,7 @@ class AdminGenericForeignKeyTestCase(AlightStory, case.AdminMixin,
 
     def test_can_select_option_in_first_inline(self):
         option, ctype = self.create_option()
-        story = stories.InlineSelectOption(self, inline_number=0)
+        story = AlightInlineSelectOption(self, inline_number=0)
         story.select_option(option.name)
         story.assert_selection_persists(
             '%s-%s' % (ctype.pk, option.pk),
@@ -36,6 +36,6 @@ class AdminGenericForeignKeyTestCase(AlightStory, case.AdminMixin,
 
     def test_can_select_option_in_first_extra_inline(self):
         option, ctype = self.create_option()
-        story = stories.InlineSelectOption(self, inline_number=3)
+        story = AlightInlineSelectOption(self, inline_number=3)
         story.select_option(option.name)
         story.assert_value('%s-%s' % (ctype.pk, option.pk))

--- a/test_project/alight_linked_data/test_functional.py
+++ b/test_project/alight_linked_data/test_functional.py
@@ -1,6 +1,6 @@
-from dal.test import case, stories
+from dal.test import case
 from dal.test.utils import OwnedFixtures
-from dal_alight.test import AlightStory
+from dal_alight.test import AlightInlineSelectOption, AlightSelectOption, AlightStory
 
 from .models import TModel
 
@@ -33,7 +33,7 @@ class AdminLinkedDataTestCase(
 
     def test_filter_options(self, story=None):
         if story is None:
-            story = stories.SelectOption(self)
+            story = AlightSelectOption(self)
 
         self.set_owner(self.fixtures.test.pk)
         story.toggle_autocomplete()
@@ -55,10 +55,10 @@ class AdminLinkedDataTestCase(
 
     def test_filter_option_in_first_inline(self):
         self.prefix = '%s-%s-' % (self.inline_related_name, 0)
-        story = stories.InlineSelectOption(self, inline_number=0)
+        story = AlightInlineSelectOption(self, inline_number=0)
         self.test_filter_options(story)
 
     def test_can_select_option_in_first_extra_inline(self):
-        story = stories.InlineSelectOption(self, inline_number=3)
+        story = AlightInlineSelectOption(self, inline_number=3)
         self.prefix = '%s-%s-' % (self.inline_related_name, 3)
         self.test_filter_options(story)

--- a/test_project/alight_list/test_functional.py
+++ b/test_project/alight_list/test_functional.py
@@ -1,5 +1,5 @@
-from dal.test import case, stories
-from dal_alight.test import AlightStory
+from dal.test import case
+from dal_alight.test import AlightCreateOption, AlightSelectOption, AlightStory
 
 from .models import TModel
 
@@ -18,20 +18,20 @@ class AdminListTestCase(
         self.browser.fill('name', 'test_%s' % self.id())
 
     def test_can_select_from_list(self):
-        story = stories.SelectOption(self)
+        story = AlightSelectOption(self)
         story.select_option('apple')
         story.assert_selection_persists(
             'apple', 'apple',
         )
 
     def test_can_create_new_item(self):
-        story = stories.AlightCreateOption(self)
+        story = AlightCreateOption(self)
         new_value = 'starfruit'
         story.create_option(new_value)
         story.assert_selection_persists(new_value, new_value)
 
     def test_suggestions_filter_by_query(self):
-        story = stories.SelectOption(self)
+        story = AlightSelectOption(self)
         story.toggle_autocomplete()
         self.enter_text(self.input_selector, 'ap')
         story.assert_suggestion_labels_are(['apple', 'apricot'])

--- a/test_project/alight_many_to_many/test_functional.py
+++ b/test_project/alight_many_to_many/test_functional.py
@@ -1,5 +1,9 @@
-from dal.test import case, stories
-from dal_alight.test import AlightStory
+from dal.test import case
+from dal_alight.test import (
+    AlightCreateOptionMultiple,
+    AlightSelectOptionMultiple,
+    AlightStory,
+)
 
 from .models import TModel
 
@@ -22,7 +26,7 @@ class AdminManyToManyTestCase(
     def test_can_select_multiple_options(self):
         opt1 = self.create_option()
         opt2 = self.create_option()
-        story = stories.SelectOptionMultiple(self)
+        story = AlightSelectOptionMultiple(self)
         story.select_option(opt1.name)
         story.select_option(opt2.name)
         story.assert_selection_persists(
@@ -31,7 +35,7 @@ class AdminManyToManyTestCase(
         )
 
     def test_can_create_option_on_the_fly(self):
-        story = stories.AlightCreateOptionMultiple(self)
+        story = AlightCreateOptionMultiple(self)
         existing = self.create_option()
         story.select_option(existing.name)
 

--- a/test_project/alight_nestedadmin/test_functional.py
+++ b/test_project/alight_nestedadmin/test_functional.py
@@ -1,8 +1,8 @@
 import json
 import time
 
-from dal.test import case, stories
-from dal_alight.test import AlightStory
+from dal.test import case
+from dal_alight.test import AlightSelectOption, AlightStory
 
 from .models import TModelOne
 
@@ -35,7 +35,7 @@ class AdminNestedLinkedDataTest(AlightStory,
 
         self.browser.execute_script(script)
 
-        story = stories.SelectOption(self)
+        story = AlightSelectOption(self)
         story.toggle_autocomplete()
 
         # The component debounces requests by 200ms; wait for the XHR to fire.

--- a/test_project/alight_one_to_one/test_functional.py
+++ b/test_project/alight_one_to_one/test_functional.py
@@ -1,7 +1,7 @@
 import uuid
 
-from dal.test import case, stories
-from dal_alight.test import AlightStory
+from dal.test import case
+from dal_alight.test import AlightCreateOption, AlightStory
 
 from .models import TModel
 
@@ -21,7 +21,7 @@ class AdminOneToOneTestCase(
         self.get(url=self.get_modeladmin_url('add'))
 
     def test_can_create_option_on_the_fly(self):
-        story = stories.AlightCreateOption(self)
+        story = AlightCreateOption(self)
         name = str(uuid.uuid4())
 
         self.enter_text('#id_name', 'parent-%s' % name)
@@ -37,7 +37,7 @@ class AdminOneToOneTestCase(
         story.assert_label(name)
 
     def test_create_option_validation(self):
-        story = stories.AlightCreateOption(self)
+        story = AlightCreateOption(self)
         story.create_option('not a slug')
         story.case.browser.is_element_present_by_css('.invalid-feedback')
         story.toggle_autocomplete()

--- a/test_project/alight_outside_admin/test_functional.py
+++ b/test_project/alight_outside_admin/test_functional.py
@@ -1,8 +1,11 @@
+import time
+import uuid
+
 from alight_many_to_many.models import TModel
 from django.urls import reverse
 
-from dal.test import case, stories
-from dal_alight.test import AlightStory
+from dal.test import case
+from dal_alight.test import AlightSelectOptionMultiple, AlightStory
 
 
 class AlightOutsideAdminTestCase(
@@ -28,7 +31,7 @@ class AlightOutsideAdminTestCase(
 
     def test_can_select_option(self):
         opt = self.create_option()
-        story = stories.SelectOptionMultiple(self)
+        story = AlightSelectOptionMultiple(self)
         story.select_option(opt.name)
         labels = [
             self.clean_label(el.text)
@@ -37,9 +40,15 @@ class AlightOutsideAdminTestCase(
         assert opt.name in labels
 
     def test_form_submits_with_selection(self):
-        opt = self.create_option()
-        story = stories.SelectOptionMultiple(self)
+        edited = TModel.objects.order_by('name').first()
+        assert edited is not None
+        edited_pk = edited.pk
+        # Name must sort after the edited row so get_object() still returns
+        # edited on POST (view always uses TModel.objects.first()).
+        opt = self.model.objects.create(name='zzz-' + str(uuid.uuid1()))
+        story = AlightSelectOptionMultiple(self)
         story.select_option(opt.name)
         self.browser.find_by_css('[type=submit]').first.click()
-        obj = TModel.objects.first()
-        assert obj is not None
+        time.sleep(2)
+        edited = TModel.objects.get(pk=edited_pk)
+        assert edited.test.filter(pk=opt.pk).exists()

--- a/test_project/alight_rename_forward/test_functional.py
+++ b/test_project/alight_rename_forward/test_functional.py
@@ -1,6 +1,6 @@
-from dal.test import case, stories
+from dal.test import case
 from dal.test.utils import OwnedFixtures
-from dal_alight.test import AlightStory
+from dal_alight.test import AlightSelectOption, AlightStory
 
 from .models import TModel
 
@@ -29,7 +29,7 @@ class AdminRenameForwardTest(
             "document.querySelector('[name=owner]').value = %d"
             % self.fixtures.test.pk
         )
-        story = stories.SelectOption(self)
+        story = AlightSelectOption(self)
         story.toggle_autocomplete()
 
         story.assert_suggestion_labels_are(

--- a/test_project/alight_secure_data/test_functional.py
+++ b/test_project/alight_secure_data/test_functional.py
@@ -1,6 +1,6 @@
-from dal.test import case, stories
+from dal.test import case
 from dal.test.utils import OwnedFixtures
-from dal_alight.test import AlightStory
+from dal_alight.test import AlightSelectOption, AlightStory
 
 from .models import TModel
 
@@ -25,7 +25,7 @@ class AdminSecureDataTest(
         self.get(url=self.get_modeladmin_url('add'))
 
     def test_filtered_options(self):
-        story = stories.SelectOption(self)
+        story = AlightSelectOption(self)
         story.toggle_autocomplete()
 
         story.assert_suggestion_labels_are(

--- a/test_project/alight_tag/test_functional.py
+++ b/test_project/alight_tag/test_functional.py
@@ -1,5 +1,10 @@
-from dal.test import case, stories
-from dal_alight.test import AlightStory
+from dal.test import case
+from dal_alight.test import (
+    AlightCreateOption,
+    AlightSelectOption,
+    AlightSelectOptionMultiple,
+    AlightStory,
+)
 
 from .models import TModel
 
@@ -17,23 +22,23 @@ class AdminTagTestCase(
         self.get(url=self.get_modeladmin_url('add'))
 
     def test_can_add_existing_tag(self):
-        story = stories.SelectOption(self)
+        story = AlightSelectOption(self)
         story.select_option('python')
         story.assert_label('python')
 
     def test_can_create_new_tag(self):
-        story = stories.AlightCreateOption(self)
+        story = AlightCreateOption(self)
         story.create_option('newtag')
         story.assert_label('newtag')
 
     def test_can_add_multiple_tags(self):
-        story = stories.SelectOptionMultiple(self)
+        story = AlightSelectOptionMultiple(self)
         story.select_option('django')
         story.select_option('python')
         story.assert_labels(['django', 'python'])
 
     def test_tags_persist_after_submit(self):
-        story = stories.SelectOptionMultiple(self)
+        story = AlightSelectOptionMultiple(self)
         story.select_option('django')
         story.select_option('css')
         story.assert_selection_persists(
@@ -42,7 +47,7 @@ class AdminTagTestCase(
         )
 
     def test_tags_survive_list_refresh(self):
-        story = stories.SelectOptionMultiple(self)
+        story = AlightSelectOptionMultiple(self)
         story.select_option('django')
         story.assert_labels(['django'])
         # Refresh the dropdown by typing a new query
@@ -52,7 +57,7 @@ class AdminTagTestCase(
         story.assert_labels(['django'])
 
     def test_tags_dont_appear_in_dropdown_after_selection(self):
-        story = stories.SelectOptionMultiple(self)
+        story = AlightSelectOptionMultiple(self)
         story.select_option('django')
         # Clear the text left by select_option, then focus to load all remaining results
         self.browser.find_by_css(self.input_selector).first.value = ''

--- a/test_project/alight_taggit/test_forms.py
+++ b/test_project/alight_taggit/test_forms.py
@@ -49,8 +49,8 @@ class TagAlightTestMixin(object):
         # Instantiate the modelform for that instance
         form = self.form(instance=fixture)
 
-        # The alight widget wraps the <select> in <autocomplete-select>,
-        # so we use assertIn checks instead of strict HTML equality.
+        # Alight renders <autocomplete-select> with hidden value inputs, not a
+        # <select>, so we use assertIn checks instead of strict HTML equality.
         rendered = str(form['test'].as_widget())
         self.assertIn('autocomplete-select', rendered)
         self.assertIn(reverse(self.url_name), rendered)

--- a/test_project/alight_taggit/test_functional.py
+++ b/test_project/alight_taggit/test_functional.py
@@ -1,7 +1,12 @@
 from taggit.models import Tag
 
-from dal.test import case, stories
-from dal_alight.test import AlightStory
+from dal.test import case
+from dal_alight.test import (
+    AlightCreateOptionMultiple,
+    AlightInlineSelectOptionMultiple,
+    AlightSelectOptionMultiple,
+    AlightStory,
+)
 
 from .models import TModel
 
@@ -16,7 +21,7 @@ class TagAlightAdminTestMixin(AlightStory, case.AdminMixin):
         self.tag_model.objects.create(name=self.labels[1])
 
     def test_can_select_options(self):
-        story = stories.SelectOptionMultiple(self)
+        story = AlightSelectOptionMultiple(self)
         for option in self.labels:
             story.select_option(option)
         story.assert_labels(self.labels)
@@ -27,7 +32,7 @@ class TagAlightAdminTestMixin(AlightStory, case.AdminMixin):
 
     def test_can_create_new_tag(self):
         new_tag = self.id() + 'new'
-        story = stories.AlightCreateOptionMultiple(self)
+        story = AlightCreateOptionMultiple(self)
         story.create_option(new_tag)
         story.assert_labels([new_tag])
         story.submit()
@@ -35,7 +40,7 @@ class TagAlightAdminTestMixin(AlightStory, case.AdminMixin):
         story.assert_values([new_tag])
 
     def test_can_select_option_in_first_inline(self):
-        story = stories.InlineSelectOptionMultiple(self, inline_number=0)
+        story = AlightInlineSelectOptionMultiple(self, inline_number=0)
         for option in self.labels:
             story.select_option(option)
         story.assert_selection_persists(self.labels, self.labels)

--- a/test_project/requirements.txt
+++ b/test_project/requirements.txt
@@ -5,6 +5,7 @@ django-nested-admin
 django-taggit
 selenium
 pytest
+pytest-xdist
 splinter
 pytest-django
 pytest-cov

--- a/test_project/select2_foreign_key/test_functional.py
+++ b/test_project/select2_foreign_key/test_functional.py
@@ -1,5 +1,11 @@
-from dal.test import case, stories
-from dal_select2.test import Select2Story
+from dal.test import case
+from dal_select2.test import (
+    Select2AddAnotherOption,
+    Select2InlineSelectOption,
+    Select2RenameOption,
+    Select2SelectOption,
+    Select2Story,
+)
 
 from .models import TModel
 
@@ -18,25 +24,25 @@ class AdminForeignKeyTestCase(Select2Story, case.AdminMixin, case.OptionMixin,
 
     def test_can_select_option(self):
         option = self.create_option()
-        story = stories.SelectOption(self)
+        story = Select2SelectOption(self)
         story.select_option(option.name)
         story.assert_selection_persists(option.pk, option.name)
 
     def test_can_select_option_in_first_inline(self):
         option = self.create_option()
-        story = stories.InlineSelectOption(self, inline_number=0)
+        story = Select2InlineSelectOption(self, inline_number=0)
         story.select_option(option.name)
         story.assert_selection(option.pk, option.name)
 
     def test_can_select_option_in_first_extra_inline(self):
         option = self.create_option()
-        story = stories.InlineSelectOption(self, inline_number=3)
+        story = Select2InlineSelectOption(self, inline_number=3)
         story.select_option(option.name)
         story.assert_selection(option.pk, option.name)
 
     def test_can_change_selected_option(self):
         option = self.create_option()
-        story = stories.RenameOption(self)
+        story = Select2RenameOption(self)
         story.select_option(option.name)
 
         add_keys = 'new name'
@@ -47,7 +53,7 @@ class AdminForeignKeyTestCase(Select2Story, case.AdminMixin, case.OptionMixin,
         story.assert_selection_persists(option.pk, add_keys)
 
     def test_can_add_another_option(self):
-        story = stories.AddAnotherOption(self)
+        story = Select2AddAnotherOption(self)
 
         name = 'add another %s' % self.id()
         story.add_another(name)
@@ -57,7 +63,7 @@ class AdminForeignKeyTestCase(Select2Story, case.AdminMixin, case.OptionMixin,
 
     def test_can_unselect_option(self):
         option = self.create_option()
-        story = stories.SelectOption(self)
+        story = Select2SelectOption(self)
         story.select_option(option.name)
         story.submit()
 

--- a/test_project/select2_generic_foreign_key/test_functional.py
+++ b/test_project/select2_generic_foreign_key/test_functional.py
@@ -1,5 +1,9 @@
-from dal.test import case, stories
-from dal_select2.test import Select2Story
+from dal.test import case
+from dal_select2.test import (
+    Select2InlineSelectOption,
+    Select2SelectOption,
+    Select2Story,
+)
 
 from .models import TModel
 
@@ -18,7 +22,7 @@ class AdminGenericForeignKeyTestCase(Select2Story, case.AdminMixin,
 
     def test_can_select_option(self):
         option, ctype = self.create_option()
-        story = stories.SelectOption(self)
+        story = Select2SelectOption(self)
         story.select_option(option.name)
         story.assert_selection_persists(
             '%s-%s' % (ctype.pk, option.pk),
@@ -27,7 +31,7 @@ class AdminGenericForeignKeyTestCase(Select2Story, case.AdminMixin,
 
     def test_can_select_option_in_first_inline(self):
         option, ctype = self.create_option()
-        story = stories.InlineSelectOption(self, inline_number=0)
+        story = Select2InlineSelectOption(self, inline_number=0)
         story.select_option(option.name)
         story.assert_selection_persists(
             '%s-%s' % (ctype.pk, option.pk),
@@ -36,6 +40,6 @@ class AdminGenericForeignKeyTestCase(Select2Story, case.AdminMixin,
 
     def test_can_select_option_in_first_extra_inline(self):
         option, ctype = self.create_option()
-        story = stories.InlineSelectOption(self, inline_number=3)
+        story = Select2InlineSelectOption(self, inline_number=3)
         story.select_option(option.name)
         story.assert_value('%s-%s' % (ctype.pk, option.pk))

--- a/test_project/select2_linked_data/test_functional.py
+++ b/test_project/select2_linked_data/test_functional.py
@@ -1,6 +1,10 @@
-from dal.test import case, stories
+from dal.test import case
 from dal.test.utils import OwnedFixtures
-from dal_select2.test import Select2Story
+from dal_select2.test import (
+    Select2InlineSelectOption,
+    Select2SelectOption,
+    Select2Story,
+)
 
 from .models import TModel
 
@@ -31,7 +35,7 @@ class AdminLinkedDataTest(Select2Story,
 
     def test_filter_options(self, story=None):
         if story is None:
-            story = stories.SelectOption(self)
+            story = Select2SelectOption(self)
 
         story.toggle_autocomplete()
 
@@ -59,10 +63,10 @@ class AdminLinkedDataTest(Select2Story,
 
     def test_filter_option_in_first_inline(self):
         self.prefix = '%s-%s-' % (self.inline_related_name, 0)
-        story = stories.InlineSelectOption(self, inline_number=0)
+        story = Select2InlineSelectOption(self, inline_number=0)
         self.test_filter_options(story)
 
     def test_can_select_option_in_first_extra_inline(self):
-        story = stories.InlineSelectOption(self, inline_number=3)
+        story = Select2InlineSelectOption(self, inline_number=3)
         self.prefix = '%s-%s-' % (self.inline_related_name, 3)
         self.test_filter_options(story)

--- a/test_project/select2_list/test_functional.py
+++ b/test_project/select2_list/test_functional.py
@@ -1,7 +1,12 @@
 import uuid
 
-from dal.test import case, stories
-from dal_select2.test import Select2Story
+from dal.test import case
+from dal_select2.test import (
+    Select2CreateOption,
+    Select2InlineSelectOption,
+    Select2SelectOption,
+    Select2Story,
+)
 
 from .models import TModel
 
@@ -31,25 +36,25 @@ class AdminSelect2List(Select2Story, case.AdminMixin, case.OptionMixin,
 
     def test_can_select_option(self):
         option = self.create_option()
-        story = stories.SelectOption(self)
+        story = Select2SelectOption(self)
         story.select_option(option.test)
         story.assert_selection_persists(option.test, option.test)
 
     def test_can_select_option_in_first_inline(self):
         option = self.create_option()
-        story = stories.InlineSelectOption(self, inline_number=0)
+        story = Select2InlineSelectOption(self, inline_number=0)
         story.select_option(option.test)
         story.assert_selection(option.test, option.test)
 
     def test_can_select_option_in_first_extra_inline(self):
         option = self.create_option()
-        story = stories.InlineSelectOption(self, inline_number=3)
+        story = Select2InlineSelectOption(self, inline_number=3)
         story.select_option(option.test)
         story.assert_selection(option.test, option.test)
 
     def test_can_change_selected_option(self):
         option = self.create_option()
-        story = stories.SelectOption(self)
+        story = Select2SelectOption(self)
         story.select_option(option.test)
         story.assert_selection_persists(option.test, option.test)
         option = self.create_option()
@@ -58,6 +63,6 @@ class AdminSelect2List(Select2Story, case.AdminMixin, case.OptionMixin,
 
     def test_can_create_new_option(self):
         new_option_text = random_text()
-        story = stories.Select2CreateOption(self, new_option_text)
+        story = Select2CreateOption(self, new_option_text)
         story.select_option(new_option_text)
         story.assert_selection(new_option_text, new_option_text)

--- a/test_project/select2_many_to_many/test_functional.py
+++ b/test_project/select2_many_to_many/test_functional.py
@@ -1,5 +1,8 @@
-from dal.test import case, stories
-from dal_select2.test import Select2Story
+from dal.test import case
+from dal_select2.test import (
+    Select2CreateOptionMultiple,
+    Select2Story,
+)
 
 from .models import TModel
 
@@ -18,7 +21,7 @@ class AdminManyToManyTestCase(Select2Story, case.AdminMixin, case.OptionMixin,
         self.get(url=self.get_modeladmin_url('add'))
 
     def test_can_create_option_on_the_fly_and_select_existing_option(self):
-        story = stories.Select2CreateOptionMultiple(self)
+        story = Select2CreateOptionMultiple(self)
 
         option = self.create_option()
         story.select_option(option.name)

--- a/test_project/select2_nestedadmin/test_functional.py
+++ b/test_project/select2_nestedadmin/test_functional.py
@@ -1,7 +1,7 @@
 import json
 
-from dal.test import case, stories
-from dal_select2.test import Select2Story
+from dal.test import case
+from dal_select2.test import Select2SelectOption, Select2Story
 
 from .models import TModelOne
 
@@ -34,7 +34,7 @@ class AdminNestedLinkedDataTest(Select2Story,
 
         self.browser.execute_script(script)
 
-        story = stories.SelectOption(self)
+        story = Select2SelectOption(self)
         story.toggle_autocomplete()
 
         forward_val = self.browser.evaluate_script('window.forward_val')

--- a/test_project/select2_one_to_one/test_functional.py
+++ b/test_project/select2_one_to_one/test_functional.py
@@ -1,7 +1,7 @@
 import uuid
 
-from dal.test import case, stories
-from dal_select2.test import Select2Story
+from dal.test import case
+from dal_select2.test import Select2CreateOption, Select2Story
 
 from .models import TModel
 
@@ -18,7 +18,7 @@ class AdminOneToOneTestCase(Select2Story, case.AdminMixin, case.OptionMixin,
         self.get(url=self.get_modeladmin_url('add'))
 
     def test_can_create_option_on_the_fly(self):
-        story = stories.Select2CreateOption(self)
+        story = Select2CreateOption(self)
         name = str(uuid.uuid4())
 
         self.enter_text('#id_name', 'parent-%s' % name)
@@ -34,7 +34,7 @@ class AdminOneToOneTestCase(Select2Story, case.AdminMixin, case.OptionMixin,
         story.assert_label(name)
 
     def test_create_option_validation(self):
-        story = stories.Select2CreateOption(self)
+        story = Select2CreateOption(self)
         story.create_option('not a slug')
         story.case.browser.is_element_present_by_css('.invalid-feedback')
         story.toggle_autocomplete()  # close autocomplete

--- a/test_project/select2_secure_data/test_functional.py
+++ b/test_project/select2_secure_data/test_functional.py
@@ -1,6 +1,6 @@
-from dal.test import case, stories
+from dal.test import case
 from dal.test.utils import OwnedFixtures
-from dal_select2.test import Select2Story
+from dal_select2.test import Select2SelectOption, Select2Story
 
 from .models import TModel
 
@@ -21,7 +21,7 @@ class AdminLinkedDataTest(Select2Story, case.AdminMixin, case.OptionMixin,
         self.get(url=self.get_modeladmin_url('add'))
 
     def test_filtered_options(self):
-        story = stories.SelectOption(self)
+        story = Select2SelectOption(self)
         story.toggle_autocomplete()
 
         story.assert_suggestion_labels_are(

--- a/test_project/select2_taggit/test_functional.py
+++ b/test_project/select2_taggit/test_functional.py
@@ -1,7 +1,11 @@
 from taggit.models import Tag
 
-from dal.test import case, stories
-from dal_select2.test import Select2Story
+from dal.test import case
+from dal_select2.test import (
+    Select2InlineSelectOptionMultiple,
+    Select2SelectOptionMultiple,
+    Select2Story,
+)
 
 from .models import TModel
 
@@ -16,7 +20,7 @@ class TagSelect2AdminTestMixin(Select2Story, case.AdminMixin):
         self.tag_model.objects.create(name=self.labels[0])
 
     def test_can_select_options(self):
-        story = stories.SelectOptionMultiple(self)
+        story = Select2SelectOptionMultiple(self)
 
         for option in self.labels:
             story.select_option(option)
@@ -33,7 +37,7 @@ class TagSelect2AdminTestMixin(Select2Story, case.AdminMixin):
         story.assert_values(self.labels)
 
     def test_can_select_option_in_first_inline(self):
-        story = stories.InlineSelectOptionMultiple(self, inline_number=0)
+        story = Select2InlineSelectOptionMultiple(self, inline_number=0)
 
         for option in self.labels:
             story.select_option(option)

--- a/test_project/tests/test_widgets.py
+++ b/test_project/tests/test_widgets.py
@@ -53,7 +53,9 @@ class SelectTest(test.TestCase):  # noqa
 
         form = Form(http.QueryDict('test=4'))
         expected = '''
-<select data-autocomplete-light-url="/test-url/" id="id_test" name="test">
+<select data-autocomplete-light-function="select2"\
+ data-autocomplete-light-language="en"\
+ data-autocomplete-light-url="/test-url/" id="id_test" name="test">
 <option value="4" %s>label for 4</option>
 </select>
         '''.strip() % selected_tag()

--- a/test_project/tests/test_widgets.py
+++ b/test_project/tests/test_widgets.py
@@ -53,9 +53,7 @@ class SelectTest(test.TestCase):  # noqa
 
         form = Form(http.QueryDict('test=4'))
         expected = '''
-<select data-autocomplete-light-function="select2"\
- data-autocomplete-light-language="en"\
- data-autocomplete-light-url="/test-url/" id="id_test" name="test">
+<select id="id_test" name="test">
 <option value="4" %s>label for 4</option>
 </select>
         '''.strip() % selected_tag()

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ setenv =
     DJANGO_SETTINGS_MODULE=settings.base
 
 commands =
-    pytest -v --cov --liveserver 127.0.0.1:9999 {posargs} alight_foreign_key alight_many_to_many alight_linked_data alight_list alight_tag alight_one_to_one alight_forward_different_fields alight_rename_forward alight_secure_data alight_outside_admin alight_taggit alight_generic_foreign_key alight_nestedadmin alight_djhacker_formfield select2_secure_data select2_rename_forward select2_foreign_key select2_generic_foreign_key select2_linked_data select2_list select2_many_to_many select2_one_to_one select2_outside_admin select2_taggit custom_select2 select2_nestedadmin select2_djhacker_formfield select2_forward_different_fields
+    pytest -v --cov --liveserver 127.0.0.1:9999 {posargs} -n auto alight_foreign_key alight_many_to_many alight_linked_data alight_list alight_tag alight_one_to_one alight_forward_different_fields alight_rename_forward alight_secure_data alight_outside_admin alight_taggit alight_generic_foreign_key alight_nestedadmin alight_djhacker_formfield select2_secure_data select2_rename_forward select2_foreign_key select2_generic_foreign_key select2_linked_data select2_list select2_many_to_many select2_one_to_one select2_outside_admin select2_taggit custom_select2 select2_nestedadmin select2_djhacker_formfield select2_forward_different_fields
 
 deps =
     dj52: Django==5.2.*

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ setenv =
     DJANGO_SETTINGS_MODULE=settings.base
 
 commands =
-    pytest -v --cov --liveserver 127.0.0.1:9999 {posargs} -n auto alight_foreign_key alight_many_to_many alight_linked_data alight_list alight_tag alight_one_to_one alight_forward_different_fields alight_rename_forward alight_secure_data alight_outside_admin alight_taggit alight_generic_foreign_key alight_nestedadmin alight_djhacker_formfield select2_secure_data select2_rename_forward select2_foreign_key select2_generic_foreign_key select2_linked_data select2_list select2_many_to_many select2_one_to_one select2_outside_admin select2_taggit custom_select2 select2_nestedadmin select2_djhacker_formfield select2_forward_different_fields
+    pytest -v --cov --liveserver 127.0.0.1:9999 {posargs} -n auto alight_foreign_key alight_many_to_many alight_linked_data alight_list alight_tag alight_one_to_one alight_forward_different_fields alight_rename_forward alight_secure_data alight_outside_admin alight_taggit alight_generic_foreign_key alight_nestedadmin alight_djhacker_formfield select2_secure_data select2_rename_forward select2_foreign_key select2_generic_foreign_key select2_linked_data select2_list select2_many_to_many select2_one_to_one select2_outside_admin select2_taggit custom_select2 select2_nestedadmin select2_djhacker_formfield select2_forward_different_fields tests
 
 deps =
     dj52: Django==5.2.*


### PR DESCRIPTION
5.1.0

    BC BREAK: whatever hack you had to implement to design the text input for
    the alight web component: you can now set the widget attrs directly.

    Changed
    - dal_alight: Django widget attrs (``id``, classes, etc.) are rendered
      on the visible search ``<input>`` instead of a hidden ``<select>``.
      The search field is the only part of the widget that needs theming;
      ``<label for="…">`` and admin field identity follow the input as
      usual.

    - dal_alight: selected values are submitted via ``<input type="hidden"
      slot="values">`` (and deck chips) instead of a hidden
      ``<select slot="select">``.  This removed a large amount of
      option-sync logic from the JS.

    - dal_alight: ``ListAlight`` now requires a ``url``.  Client-side
      local filtering of ``<option>`` elements was removed to keep the JS
      small.  For a static choice list without a server round-trip, use a
      normal ``<select>`` in your UI — as long as select and text-input
      styling match your theme, the experience stays consistent.

    - dal_alight: removed ``Alight`` and ``AlightMultiple`` widgets.
      They were redundant with ``ListAlight`` (single) and
      ``ModelAlightMultiple`` / ``TagAlight`` (multi) after client-side
      filtering was dropped.  Migrate ``Alight`` → ``ListAlight`` with
      ``AlightListView``.

    - dal.test.stories: backend-specific Selenium story classes moved to
      ``dal_alight.test`` and ``dal_select2.test``. Shared stories raise
      ``NotImplementedError`` for value assertions; functional tests
      import the appropriate backend subclass.

    Improvements
    - dal_alight: widgets extend ``forms.TextInput`` (via
      ``AlightChoiceMixin`` for choice/deck plumbing) instead of
      ``forms.Select*``.  Standard widget ``attrs`` — merged with
      ``build_attrs()`` — configure the visible search input.

    - dal.widgets: ``data-autocomplete-light-url`` and
      ``data-autocomplete-light-function`` moved from shared ``WidgetMixin`` to
      ``dal_select2.widgets.Select2WidgetMixin`` (Select2-only).

    - test_project: tests run in parallel via ``pytest-xdist`` (``-n auto``);
      CI splits unit and browser suites into separate workflow jobs.